### PR TITLE
Don't throw an exception for an undefined symbol

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.4.3
+filterVersion=0.5.0
 
 grinderName=coffeegrinder
-grinderVersion=0.4.2
+grinderVersion=0.5.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.4.2
+filterVersion=0.4.3
 
 grinderName=coffeegrinder
 grinderVersion=0.4.2

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
@@ -239,8 +239,10 @@ public class InvisibleXmlDocument {
         try {
             handler.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
-            attrs.addAttribute("http://invisiblexml.org/NS", "ixml:state", "failed");
+            handler.startPrefixMapping(CommonBuilder.ixml_prefix, CommonBuilder.ixml_ns);
+
+            AttributeBuilder attrs = new AttributeBuilder(options);
+            attrs.addAttribute(CommonBuilder.ixml_ns, CommonBuilder.ixml_prefix + ":state", "failed");
             handler.startElement("", "fail", "failed", attrs);
 
             if (lineNumber > 0) {
@@ -283,11 +285,11 @@ public class InvisibleXmlDocument {
 
                 for (int row = 0; row < result.getChart().size(); row++) {
                     if (!result.getChart().get(row).isEmpty()) {
-                        attrs = new AttributeBuilder();
+                        attrs = new AttributeBuilder(options);
                         attrs.addAttribute("n", ""+row);
                         handler.startElement("", "row", "row", attrs);
 
-                        attrs = new AttributeBuilder();
+                        attrs = new AttributeBuilder(options);
                         for (EarleyItem item : result.getChart().get(row)) {
                             writeString(handler,"  ");
                             handler.startElement("", "item", "item", attrs);

--- a/src/main/java/org/nineml/coffeefilter/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeefilter/ParserOptions.java
@@ -22,6 +22,8 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
         graphviz = copy.graphviz;
         suppressIxmlAmbiguous = copy.suppressIxmlAmbiguous;
         suppressIxmlPrefix = copy.suppressIxmlPrefix;
+        allowUndefinedSymbols = copy.allowUndefinedSymbols;
+        assertValidXmlNames = copy.assertValidXmlNames;
     }
 
     /**
@@ -30,6 +32,13 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
      * removed from the input, report success.</p>
      */
     public boolean ignoreTrailingWhitespace = false;
+
+    /**
+     * Allow undefined symbols.
+     * <p>A grammar with undefined symbols isn't necessarily unusable. But Invisible XML
+     * forbids them.</p>
+     */
+    public boolean allowUndefinedSymbols = false;
 
     /**
      * Attempt to pretty print the result?

--- a/src/main/java/org/nineml/coffeefilter/exceptions/IxmlException.java
+++ b/src/main/java/org/nineml/coffeefilter/exceptions/IxmlException.java
@@ -67,7 +67,7 @@ public class IxmlException extends RuntimeException {
     public static IxmlException parseFailed(Exception ex) {
         return getException("P005", new String[] { ex.getMessage() }, ex);
     }
-    public static IxmlException noRuleForSymbol(String name) { return getException("E001", name); }
+    public static IxmlException repeatedAttribute(String name) { return getException("E001", name); }
     public static IxmlException invalidCharacterClass(String name) { return getException("E002", name); }
     public static IxmlException invalidXmlName(String name) { return getException("E003", name); }
     public static IxmlException duplicateRuleForSymbol(String name) { return getException("E004", name); }

--- a/src/main/java/org/nineml/coffeefilter/model/INonterminal.java
+++ b/src/main/java/org/nineml/coffeefilter/model/INonterminal.java
@@ -82,7 +82,11 @@ public class INonterminal extends XNonterminal {
     public char getMark() {
         if (mark == '?') {
             IRule rule = getRoot().getRule(name);
-            mark = rule.getMark();
+            if (rule == null) {
+                mark = '^'; // it's irrelevant since any reference to the symbol will throw an exception
+            } else {
+                mark = rule.getMark();
+            }
         }
         return mark;
     }

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -321,8 +321,7 @@ public class Ixml extends XNonterminal {
     /**
      * Return the rule for the given name.
      * @param name The rule name.
-     * @return Return the rule.
-     * @throws IllegalArgumentException if no rule with the specified name exists.
+     * @return Return the rule, or null if no such rule exists.
      */
     public IRule getRule(String name) {
         for (XNode child : children) {
@@ -333,7 +332,7 @@ public class Ixml extends XNonterminal {
                 }
             }
         }
-        throw IxmlException.noRuleForSymbol(name);
+        return null;
     }
 
     /**

--- a/src/main/java/org/nineml/coffeefilter/utils/AttributeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/AttributeBuilder.java
@@ -1,23 +1,22 @@
 package org.nineml.coffeefilter.utils;
 
+import org.nineml.coffeefilter.ParserOptions;
+import org.nineml.coffeefilter.exceptions.IxmlException;
+import org.nineml.coffeegrinder.exceptions.GrammarException;
 import org.xml.sax.Attributes;
-import org.nineml.coffeegrinder.util.Messages;
 
 import java.util.ArrayList;
 
 public final class AttributeBuilder implements Attributes {
-    public static final Attributes EMPTY_ATTRIBUTES = new AttributeBuilder();
-    private final Messages messages;
+    public static final String logcategory = "Attributes";
+    public static final Attributes EMPTY_ATTRIBUTES = new AttributeBuilder(new ParserOptions());
+    private final ParserOptions options;
     private final ArrayList<String> names = new ArrayList<>();
     private final ArrayList<String> values = new ArrayList<>();
     private final ArrayList<String> namespaces = new ArrayList<>();
 
-    public AttributeBuilder() {
-        messages = null;
-    }
-
-    public AttributeBuilder(Messages messages) {
-        this.messages = messages;
+    public AttributeBuilder(ParserOptions options) {
+        this.options = options;
     }
 
     public void addAttribute(String name, String value) {
@@ -35,14 +34,15 @@ public final class AttributeBuilder implements Attributes {
             throw new NullPointerException("Attribute value must not be null");
         }
         if (names.contains(name)) {
+            /* Allow them if they're the same value? Not per the current spec...
             int pos = getIndex(ns, name);
             if (value.equals(getValue(pos))) {
-                if (messages != null) {
-                    messages.debug("Duplicated attribute: " + name);
-                }
-                return;
+                options.logger.debug(logcategory, "Duplicated attribute: %s", name);
+            } else {
+                throw IxmlException.repeatedAttribute(name);
             }
-            throw new RuntimeException("Duplicate attribute: " + name);
+             */
+            throw IxmlException.repeatedAttribute(name);
         }
 
         namespaces.add(ns);

--- a/src/main/java/org/nineml/coffeefilter/utils/CommonBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/CommonBuilder.java
@@ -7,7 +7,6 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacter;
-import org.nineml.coffeegrinder.util.Messages;
 import org.nineml.coffeegrinder.util.ParserAttribute;
 
 import java.util.ArrayList;
@@ -17,8 +16,11 @@ import java.util.Stack;
  * This class transforms the output of a successful ixml parse into XML.
  */
 public class CommonBuilder {
+    public static final String logcategory = "TreeBuilder";
+    public static final String ixml_prefix = "ixml";
+    public static final String ixml_ns = "http://invisiblexml.org/NS";
+
     private final ParserOptions options;
-    private final Messages messages;
     private final Stack<PartialOutput> stack = new Stack<>();
     private final Stack<Character> context = new Stack<>();
     private final Stack<String> elementStack = new Stack<>();
@@ -29,16 +31,9 @@ public class CommonBuilder {
     private boolean prefix = false;
 
     public CommonBuilder(ParseTree tree, EarleyResult result, ParserOptions options) {
-        this(tree, result, options, null);
-    }
-
-    public CommonBuilder(ParseTree tree, EarleyResult result, ParserOptions options, Messages messages) {
         this.options = options;
-        this.messages = messages;
         if (tree == null) {
-            if (messages != null) {
-                messages.detail("No tree");
-            }
+            options.logger.trace(logcategory, "No tree");
             return;
         }
         context.push('*');
@@ -297,7 +292,7 @@ public class CommonBuilder {
                 if (name == null) {
                     handler.characters(text.toCharArray(), 0, text.length());
                 } else {
-                    AttributeBuilder attrs = new AttributeBuilder();
+                    AttributeBuilder attrs = new AttributeBuilder(options);
                     for (PartialOutput attr : attributes) {
                         // Attributes are constructed with a single child that contains the value
                         String value;
@@ -323,7 +318,8 @@ public class CommonBuilder {
                         }
 
                         if (!"".equals(state)) {
-                            attrs.addAttribute("http://invisiblexml.org/NS", "ixml:state", state);
+                            handler.startPrefixMapping(ixml_prefix, ixml_ns);
+                            attrs.addAttribute(ixml_ns, ixml_prefix + ":state", state);
                         }
                     }
 

--- a/src/main/resources/org/nineml/coffeefilter/en_messages.txt
+++ b/src/main/resources/org/nineml/coffeefilter/en_messages.txt
@@ -1,4 +1,4 @@
-E001: There is no rule for the nonterminal symbol: %1.
+E001: Repeated attribute: %1.
 E002: The Unicode character class ‘%1’ is invalid.
 E003: Invalid XML Name: %1.
 E004: More than one rule for nonterminal symbol: %1.

--- a/src/test/java/org/nineml/coffeefilter/CommonBuilder.java
+++ b/src/test/java/org/nineml/coffeefilter/CommonBuilder.java
@@ -12,17 +12,17 @@ public class CommonBuilder {
 
     public DataTree buildRecordDataTree(ParserOptions options) throws SAXException {
         DataTreeBuilder builder = new DataTreeBuilder(options);
-        buildRecordTree(builder);
+        buildRecordTree(options, builder);
         return builder.getTree();
     }
 
     public SimpleTree buildRecordSimpleTree(ParserOptions options) throws SAXException {
         SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
-        buildRecordTree(builder);
+        buildRecordTree(options, builder);
         return builder.getTree();
     }
 
-    public void buildRecordTree(DefaultHandler builder) throws SAXException {
+    public void buildRecordTree(ParserOptions options, DefaultHandler builder) throws SAXException {
         builder.startDocument();
 
         builder.startElement("", "root", "root", AttributeBuilder.EMPTY_ATTRIBUTES);
@@ -54,20 +54,20 @@ public class CommonBuilder {
 
     public SimpleTree buildAttributesSimpleTree(ParserOptions options) throws SAXException {
         SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
-        buildAttributesTree(builder);
+        buildAttributesTree(options, builder);
         return builder.getTree();
     }
 
-    public void buildAttributesTree(DefaultHandler builder) throws SAXException {
+    public void buildAttributesTree(ParserOptions options, DefaultHandler builder) throws SAXException {
         builder.startDocument();
 
-        AttributeBuilder attrs = new AttributeBuilder();
+        AttributeBuilder attrs = new AttributeBuilder(options);
         attrs.addAttribute("version", "1.0");
         attrs.addAttribute("count", "2");
 
         builder.startElement("", "root", "root", attrs);
 
-        attrs = new AttributeBuilder();
+        attrs = new AttributeBuilder(options);
         attrs.addAttribute("num", "1");
 
         builder.startElement("", "record", "record", attrs);
@@ -80,7 +80,7 @@ public class CommonBuilder {
         atomic(builder, "age", "22");
         builder.endElement("", "record", "record");
 
-        attrs = new AttributeBuilder();
+        attrs = new AttributeBuilder(options);
         attrs.addAttribute("test", "string");
 
         builder.startElement("", "no-content", "no-content", attrs);

--- a/src/test/java/org/nineml/coffeefilter/DataTreeTest.java
+++ b/src/test/java/org/nineml/coffeefilter/DataTreeTest.java
@@ -45,7 +45,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
             builder.endElement("", "root", "root");
@@ -70,7 +70,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("a", "A");
             attrs.addAttribute("b", "B");
             attrs.addAttribute("empty1", "      ");
@@ -113,7 +113,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options,true);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("a", "A");
             builder.startElement("", "root", "root", attrs);
 
@@ -151,7 +151,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options,false);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("a", "A");
             builder.startElement("", "b", "b", attrs);
             builder.startElement("", "a", "a", AttributeBuilder.EMPTY_ATTRIBUTES);
@@ -322,7 +322,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
             builder.endElement("", "root", "root");
@@ -364,7 +364,7 @@ public class DataTreeTest extends CommonBuilder {
             DataTreeBuilder builder = new DataTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
 

--- a/src/test/java/org/nineml/coffeefilter/ErrorTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ErrorTest.java
@@ -67,14 +67,20 @@ public class ErrorTest {
     }
 
     @Test
-    public void undefinedNonterminal() {
-        String input = "date: ['0123'], ['0'-'9'], month, year .";
+    public void repeatedAttribute() {
+        String input = "S: @a, @a . a: 'a'; 'b' .";
 
         InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        Assert.assertTrue(parser.constructed());
 
-        Assert.assertFalse(parser.constructed());
-        Assert.assertNotNull(parser.getException());
-        Assert.assertEquals("E001", ((IxmlException) parser.getException()).getCode());
+        InvisibleXmlDocument doc = parser.parse("aa");
+
+        try {
+            String tree = doc.getTree();
+            fail();
+        } catch (IxmlException ex) {
+            Assert.assertEquals("E001", ex.getCode());
+        }
     }
 
     @Test

--- a/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
+++ b/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
@@ -49,7 +49,7 @@ public class SimpleTreeTest extends CommonBuilder {
             SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
             builder.characters("abc".toCharArray(), 0, 3);
@@ -77,7 +77,7 @@ public class SimpleTreeTest extends CommonBuilder {
             SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
             builder.characters("   ".toCharArray(), 0, 3);
@@ -105,7 +105,7 @@ public class SimpleTreeTest extends CommonBuilder {
             SimpleTreeBuilder builder = new SimpleTreeBuilder(options,true);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
             builder.characters("   ".toCharArray(), 0, 3);
@@ -150,7 +150,7 @@ public class SimpleTreeTest extends CommonBuilder {
             SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             attrs.addAttribute("test2", "fork");
             builder.startElement("", "root", "root", attrs);
@@ -181,11 +181,11 @@ public class SimpleTreeTest extends CommonBuilder {
             SimpleTreeBuilder builder = new SimpleTreeBuilder(options);
             builder.startDocument();
 
-            AttributeBuilder attrs = new AttributeBuilder();
+            AttributeBuilder attrs = new AttributeBuilder(options);
             attrs.addAttribute("test", "spoon");
             builder.startElement("", "root", "root", attrs);
 
-            attrs = new AttributeBuilder();
+            attrs = new AttributeBuilder(options);
             attrs.addAttribute("a", "1");
             attrs.addAttribute("b", "2");
             builder.startElement("", "attronly", "attronly", attrs);

--- a/src/test/java/org/nineml/coffeefilter/TestDriver.java
+++ b/src/test/java/org/nineml/coffeefilter/TestDriver.java
@@ -105,10 +105,11 @@ public class TestDriver {
         int pass = 0;
         int count = 0;
         for (XdmNode testCase : testsToRun) {
+            XdmNode testSet = testCase.getParent();
             count++;
             String name = testCase.getAttributeValue(_name);
             if (name == null) {
-                System.err.printf("Running test %d of %d:%n", count, testsToRun.size());
+                System.err.printf("Running test %d of %d (from %s):%n", count, testsToRun.size(), testSet.getAttributeValue(_name));
             } else {
                 System.err.printf("Running %s, test %d of %d:%n", name, count, testsToRun.size());
             }


### PR DESCRIPTION
To support having undefined symbols be a hygiene problem.
