### PR TITLE
The InvisibleXml object is no longer static

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.5.0
+filterVersion=0.6.0
 
 grinderName=coffeegrinder
 grinderVersion=0.5.0

--- a/src/main/java/org/nineml/coffeefilter/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeefilter/ParserOptions.java
@@ -18,7 +18,6 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
         ignoreTrailingWhitespace = copy.ignoreTrailingWhitespace;
         prettyPrint = copy.prettyPrint;
         showChart = copy.showChart;
-        verbose = copy.verbose;
         graphviz = copy.graphviz;
         suppressIxmlAmbiguous = copy.suppressIxmlAmbiguous;
         suppressIxmlPrefix = copy.suppressIxmlPrefix;
@@ -49,11 +48,6 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
      * Show the Earley chart in error results?
      */
     public boolean showChart = false;
-
-    /**
-     * Be verbose about what's going on?
-     */
-    public boolean verbose = false;
 
     /**
      * Where's the GraphViz 'dot' command?

--- a/src/test/java/org/nineml/coffeefilter/CompiledGrammarTest.java
+++ b/src/test/java/org/nineml/coffeefilter/CompiledGrammarTest.java
@@ -13,10 +13,12 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.fail;
 
 public class CompiledGrammarTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
+
     @Test
     public void parseIxmlGrammar() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/date.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/date.ixml"));
             InvisibleXmlDocument doc = parser.parse("1 January 2022");
             Assert.assertEquals("<date><day>1</day><month>January</month><year>2022</year></date>", doc.getTree());
         } catch (Exception ex) {
@@ -27,7 +29,7 @@ public class CompiledGrammarTest {
     @Test
     public void parseCompiledGrammar() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/date.cxml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/date.cxml"));
             InvisibleXmlDocument doc = parser.parse("1 January 2022");
             Assert.assertEquals("<date><day>1</day><month>January</month><year>2022</year></date>", doc.getTree());
         } catch (Exception ex) {
@@ -38,7 +40,7 @@ public class CompiledGrammarTest {
     @Test
     public void compileHashGrammar() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("ixml/tests/correct/hash.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/correct/hash.ixml"));
             InvisibleXmlDocument doc = parser.parse("#12.");
             //doc.getEarleyResult().getForest().parse().serialize("hash.xml");
             //doc.getEarleyResult().getForest().serialize("graph.xml");
@@ -47,7 +49,7 @@ public class CompiledGrammarTest {
 
             ByteArrayInputStream bais = new ByteArrayInputStream(compiled.getBytes(StandardCharsets.UTF_8));
 
-            parser = InvisibleXml.getParser(bais, null);
+            parser = invisibleXml.getParser(bais, null);
             doc = parser.parse("#12.");
             //doc.getEarleyResult().getForest().parse().serialize("hash2.xml");
             //doc.getEarleyResult().getForest().serialize("graph2.xml");

--- a/src/test/java/org/nineml/coffeefilter/ErrorTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ErrorTest.java
@@ -9,6 +9,8 @@ import org.nineml.coffeefilter.utils.TokenUtils;
 import static junit.framework.TestCase.fail;
 
 public class ErrorTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
+
     @Test
     public void invalidXmlNames() {
         Assert.assertTrue(TokenUtils.xmlName("test"));
@@ -22,7 +24,7 @@ public class ErrorTest {
     @Test
     public void invalidXmlName() {
         String grammar = "\u00AA: 'a' .";
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(grammar);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(grammar);
 
         String input = "a";
         InvisibleXmlDocument doc = parser.parse(input);
@@ -47,7 +49,7 @@ public class ErrorTest {
     @Test
     public void validJsonName() {
         String grammar = "\u00AA: 'a' .";
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(grammar);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(grammar);
 
         String input = "a";
         InvisibleXmlDocument doc = parser.parse(input);
@@ -70,7 +72,7 @@ public class ErrorTest {
     public void repeatedAttribute() {
         String input = "S: @a, @a . a: 'a'; 'b' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertTrue(parser.constructed());
 
         InvisibleXmlDocument doc = parser.parse("aa");
@@ -88,7 +90,7 @@ public class ErrorTest {
         String input = "date: ['0123'], ['0'-'9'] .\n" +
                 "date: 'January' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -99,7 +101,7 @@ public class ErrorTest {
     public void badHex() {
         String input = "date: [#00decafbad00badbadbad] .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -107,7 +109,7 @@ public class ErrorTest {
 
         input = "date: [#ffffffff0] .";
 
-        parser = InvisibleXml.getParserFromIxml(input);
+        parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -115,7 +117,7 @@ public class ErrorTest {
 
         input = "date: [#fffe] .";
 
-        parser = InvisibleXml.getParserFromIxml(input);
+        parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -123,7 +125,7 @@ public class ErrorTest {
 
         input = "date: [#1fffe] .";
 
-        parser = InvisibleXml.getParserFromIxml(input);
+        parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -131,7 +133,7 @@ public class ErrorTest {
 
         input = "date: [#d801] .";
 
-        parser = InvisibleXml.getParserFromIxml(input);
+        parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -142,7 +144,7 @@ public class ErrorTest {
     public void badUnicodeClass() {
         String input = "s: [Xq] .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
 
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
@@ -153,7 +155,7 @@ public class ErrorTest {
     public void rootAttribute() {
         String input = "@s: 'a' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertTrue(parser.constructed());
         InvisibleXmlDocument doc = parser.parse("a");
         Assert.assertTrue(doc.succeeded());
@@ -170,7 +172,7 @@ public class ErrorTest {
     public void alsoRootAttribute() {
         String input = "-s: t. @t: 'a' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertTrue(parser.constructed());
         InvisibleXmlDocument doc = parser.parse("a");
         Assert.assertTrue(doc.succeeded());
@@ -187,7 +189,7 @@ public class ErrorTest {
     public void multipleRoots() {
         String input = "-s: t, u. t: 't' . u: 'u' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertTrue(parser.constructed());
         InvisibleXmlDocument doc = parser.parse("tu");
         Assert.assertTrue(doc.succeeded());
@@ -204,7 +206,7 @@ public class ErrorTest {
     public void emptyOutput() {
         String input = "s: -'a' .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertTrue(parser.constructed());
         InvisibleXmlDocument doc = parser.parse("a");
         Assert.assertTrue(doc.succeeded());
@@ -217,7 +219,7 @@ public class ErrorTest {
     public void invalidRange() {
         String input = "s: ['Z'-'A'] .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         Assert.assertFalse(parser.constructed());
         Assert.assertNotNull(parser.getException());
         Assert.assertEquals("E010", ((IxmlException) parser.getException()).getCode());

--- a/src/test/java/org/nineml/coffeefilter/IxmlParserTest.java
+++ b/src/test/java/org/nineml/coffeefilter/IxmlParserTest.java
@@ -11,10 +11,12 @@ import java.io.File;
 import static org.junit.Assert.fail;
 
 public class IxmlParserTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
+
     @Test
     public void testParseIxml() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/main/resources/org/nineml/coffeefilter/ixml.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/main/resources/org/nineml/coffeefilter/ixml.ixml"));
             Grammar grammar = parser.getGrammar();
             Assert.assertNotNull(grammar);
             //System.err.println(parser.getCompiledParser());
@@ -27,7 +29,7 @@ public class IxmlParserTest {
     @Test
     public void testParseExceptions() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
             Grammar grammar = parser.getGrammar();
             Assert.assertNotNull(grammar);
             //System.err.println(parser.getCompiledParser());

--- a/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import static org.junit.Assert.fail;
 
 public class ParserFailTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
 
     @Test
     public void parseDate() {
@@ -21,7 +22,7 @@ public class ParserFailTest {
                 "       \"September\"; \"October\"; \"November\"; \"December\".\n" +
                 "year: ((digit, digit); -\"'\")?, digit, digit .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
 
         input = "16 Jinglebells 1992";
         InvisibleXmlDocument doc = parser.parse(input);

--- a/src/test/java/org/nineml/coffeefilter/ParserTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ParserTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import static org.junit.Assert.fail;
 
 public class ParserTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
 
     @Test
     public void parseDate() {
@@ -22,7 +23,7 @@ public class ParserTest {
                 "       \"September\"; \"October\"; \"November\"; \"December\".\n" +
                 "year: ((digit, digit); -\"'\")?, digit, digit .";
 
-        InvisibleXmlParser parser = InvisibleXml.getParserFromIxml(input);
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
 
         input = "16 June '67";
         InvisibleXmlDocument doc = parser.parse(input);
@@ -51,7 +52,7 @@ public class ParserTest {
     @Test
     public void hash() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("ixml/tests/correct/hash.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/correct/hash.ixml"));
 
             String input = "#12.";
             InvisibleXmlDocument doc = parser.parse(input);
@@ -76,7 +77,7 @@ public class ParserTest {
     @Test
     public void vcard() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("ixml/tests/correct/vcard.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/correct/vcard.ixml"));
 
             String input = "BEGIN:VCARD\n" +
                     "VERSION:3.0\n" +
@@ -112,7 +113,7 @@ public class ParserTest {
     @Test
     public void css() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("ixml/tests/ambiguous/css.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/ambiguous/css.ixml"));
             String input = "body { color: blue;}";
 
             InvisibleXmlDocument doc = parser.parse(input);
@@ -129,7 +130,7 @@ public class ParserTest {
     @Test
     public void ambig2() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("ixml/tests/ambiguous/ambig2.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/ambiguous/ambig2.ixml"));
             String input = "";
             InvisibleXmlDocument doc = parser.parse(input);
             Assert.assertEquals("<a/>", doc.getTree());
@@ -142,7 +143,7 @@ public class ParserTest {
     @Test
     public void comments() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/comments.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/comments.ixml"));
             String input = "hello";
             InvisibleXmlDocument doc = parser.parse(input);
             Assert.assertTrue(doc.getNumberOfParses() > 0);

--- a/src/test/java/org/nineml/coffeefilter/ReportTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ReportTest.java
@@ -8,10 +8,12 @@ import org.nineml.coffeegrinder.parser.NonterminalSymbol;
 import java.io.File;
 
 public class ReportTest {
+    private static InvisibleXml invisibleXml = new InvisibleXml();
+
     @Test
     public void testHygieneReport() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/unproductive.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/unproductive.ixml"));
             Assertions.assertTrue(parser.constructed());
 
             HygieneReport report = parser.getHygieneReport();

--- a/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
+++ b/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
@@ -12,7 +12,8 @@ import java.io.File;
 import static junit.framework.TestCase.fail;
 
 public class SimpleTreeTest extends CommonBuilder {
-    ParserOptions options = new ParserOptions();
+    private static ParserOptions options = new ParserOptions();
+    private static InvisibleXml invisibleXml = new InvisibleXml(options);
 
     @Test
     public void emptyTree() {
@@ -126,7 +127,7 @@ public class SimpleTreeTest extends CommonBuilder {
     @Test
     public void testExceptions() {
         try {
-            InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
 
             String input = "set \"a\"\n" +
                     "set \"b\"\n" +

--- a/src/test/java/org/nineml/coffeefilter/TestDriver.java
+++ b/src/test/java/org/nineml/coffeefilter/TestDriver.java
@@ -39,6 +39,8 @@ public class TestDriver {
     public static final int STATE_PASS = 1;
     public static final int STATE_FAIL = 2;
 
+    public static ParserOptions options = new ParserOptions();
+    public static InvisibleXml invisibleXml = new InvisibleXml(options);
     public static boolean runningEE = true;
     public static Processor processor = null;
     public static boolean ranOne = false;
@@ -130,7 +132,7 @@ public class TestDriver {
     }
 
     private void loadExceptions(String exfile) throws IOException, URISyntaxException {
-        InvisibleXmlParser parser = InvisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
+        InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/exceptions.ixml"));
         InvisibleXmlDocument doc = parser.parse(new File(exfile));
         DataTreeBuilder builder = new DataTreeBuilder(new ParserOptions());
         doc.getTree(builder);
@@ -260,7 +262,7 @@ public class TestDriver {
             throw new RuntimeException("Test case has no in-scope grammar?: " + testCase.getAttributeValue(_name));
         }
 
-        InvisibleXmlParser parser = InvisibleXml.getParser();
+        InvisibleXmlParser parser = invisibleXml.getParser();
         tresult.grammarParseTime = parser.getParseTime();
 
         InvisibleXmlDocument doc = parseGrammar(config);
@@ -405,25 +407,25 @@ public class TestDriver {
         String ixml;
         if (t_ixml_grammar.equals(config.grammar.getNodeName())) {
             ixml = config.grammar.getStringValue();
-            parser = InvisibleXml.getParserFromIxml(ixml);
+            parser = invisibleXml.getParserFromIxml(ixml);
         } else if (t_ixml_grammar_ref.equals(config.grammar.getNodeName())) {
             URI grammarURI = config.grammar.getBaseURI().resolve(config.grammar.getAttributeValue(_href));
             if (grammarURI.toString().endsWith("/ixml/tests/reference/ixml.ixml")) {
-                parser = InvisibleXml.getParser();
+                parser = invisibleXml.getParser();
             } else {
                 ixml = textFile(grammarURI);
-                parser = InvisibleXml.getParserFromIxml(ixml);
+                parser = invisibleXml.getParserFromIxml(ixml);
             }
         } else if (t_vxml_grammar.equals(config.grammar.getNodeName())) {
             ixml = config.grammar.getStringValue();
             ByteArrayInputStream bais = new ByteArrayInputStream(ixml.getBytes(StandardCharsets.UTF_8));
-            parser = InvisibleXml.getParser(bais, null);
+            parser = invisibleXml.getParser(bais, null);
         } else if (t_vxml_grammar_ref.equals(config.grammar.getNodeName())) {
             String href = config.grammar.getAttributeValue(_href);
             if (href.endsWith("/reference/ixml.xml")) {
-                parser = InvisibleXml.getParser();
+                parser = invisibleXml.getParser();
             } else {
-                parser = InvisibleXml.getParser(config.grammar.getBaseURI().resolve(href));
+                parser = invisibleXml.getParser(config.grammar.getBaseURI().resolve(href));
             }
         } else {
             throw new RuntimeException("Unexpected grammar: " + config.grammar.getNodeName());
@@ -432,7 +434,7 @@ public class TestDriver {
     }
 
     private InvisibleXmlDocument parseGrammar(TestConfiguration config) throws IOException, URISyntaxException {
-        InvisibleXmlParser parser = InvisibleXml.getParser();
+        InvisibleXmlParser parser = invisibleXml.getParser();
         InvisibleXmlDocument doc = null;
         String ixml;
         if (t_ixml_grammar.equals(config.grammar.getNodeName())) {

--- a/src/website/xml/coffeefilter.xml
+++ b/src/website/xml/coffeefilter.xml
@@ -48,7 +48,7 @@ library.</para>
         "year: ((digit, digit); -\"'\")?, digit, digit .";
 
 InvisibleXmlParser parser
-    = InvisibleXml.getParserFromIxml(input);
+    = new InvisibleXml().getParserFromIxml(input);
 
 InvisibleXmlDocument doc
      = parser.parse("27 Feb 2022");
@@ -57,7 +57,10 @@ String result = doc.getTree();
 </programlisting>
 <calloutlist>
 <callout arearefs="ex_parser">
-<para>Create a parser.
+<para>Create a parser. In early versions of this API, the
+<classname>InvisibleXml</classname> class had static methods. In version 0.6.0,
+that was changed. It must now be instantiated and the <classname>ParserOptions</classname>
+to use can be specified.
 </para>
 </callout>
 <callout arearefs="ex_doc">


### PR DESCRIPTION
That was just a disaster. It wasn't possible to reliably have different `ParserOptions` for different parsers because the default options were static.