### PR TITLE
Test improvements and copy constructor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.6.0
+filterVersion=0.6.1
 
 grinderName=coffeegrinder
-grinderVersion=0.5.0
+grinderVersion=0.5.1
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.6.1
+filterVersion=0.7.0
 
 grinderName=coffeegrinder
-grinderVersion=0.5.1
+grinderVersion=0.6.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
@@ -214,14 +214,13 @@ public class InvisibleXml {
      */
     public InvisibleXmlParser getParserFromCxml(InputStream stream, String systemId) throws IOException {
         try {
-            ParserOptions optionsCopy = new ParserOptions(options);
-            GrammarCompiler compiler = new GrammarCompiler(optionsCopy);
+            GrammarCompiler compiler = new GrammarCompiler(options);
             long startMillis = Calendar.getInstance().getTimeInMillis();
             Grammar grammar = compiler.parse(stream, systemId);
             Ixml ixml = new Ixml(grammar);
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
             InvisibleXmlParser parser = new InvisibleXmlParser(ixml, parseMillis);
-            parser.setOptions(optionsCopy);
+            parser.setOptions(options);
             return parser;
         } catch (CoffeeGrinderException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
@@ -242,14 +241,13 @@ public class InvisibleXml {
         factory.setValidating(false);
         IxmlContentHandler handler = new IxmlContentHandler();
         try {
-            ParserOptions optionsCopy = new ParserOptions(options);
             SAXParser parser = factory.newSAXParser();
             long startMillis = Calendar.getInstance().getTimeInMillis();
             parser.parse(stream, handler, systemId);
-            Ixml ixml = handler.getIxml(optionsCopy);
+            Ixml ixml = handler.getIxml(options);
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
             InvisibleXmlParser iparser = new InvisibleXmlParser(ixml, parseMillis);
-            iparser.setOptions(optionsCopy);
+            iparser.setOptions(options);
             return iparser;
         } catch (ParserConfigurationException|SAXException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
@@ -267,10 +265,8 @@ public class InvisibleXml {
      * @throws IxmlException if the input is not an ixml grammar
      */
     public InvisibleXmlParser getParserFromIxml(InputStream stream, String charset) throws IOException {
-        ParserOptions opts = new ParserOptions(options);
-
         InvisibleXmlParser ixmlParser = getParser();
-        ixmlParser.setOptions(opts);
+        ixmlParser.setOptions(options);
 
         InvisibleXmlDocument doc = ixmlParser.parse(stream, charset);
         if (doc.getNumberOfParses() == 0) {
@@ -278,12 +274,12 @@ public class InvisibleXml {
         }
 
         ParseTree tree = doc.getEarleyResult().getForest().parse();
-        CommonBuilder builder = new CommonBuilder(tree, doc.getEarleyResult(), opts);
+        CommonBuilder builder = new CommonBuilder(tree, doc.getEarleyResult(), options);
 
         try {
             IxmlContentHandler handler = new IxmlContentHandler();
             builder.build(handler);
-            Ixml ixml = handler.getIxml(new ParserOptions(options));
+            Ixml ixml = handler.getIxml(options);
 
             InvisibleXmlParser parser = new InvisibleXmlParser(ixml, doc.getEarleyResult().getParseTime());
 

--- a/src/main/java/org/nineml/coffeefilter/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeefilter/ParserOptions.java
@@ -10,22 +10,6 @@ public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions
     }
 
     /**
-     * A copy constructor.
-     * @param copy the options to copy.
-     */
-    public ParserOptions(ParserOptions copy) {
-        super(copy);
-        ignoreTrailingWhitespace = copy.ignoreTrailingWhitespace;
-        prettyPrint = copy.prettyPrint;
-        showChart = copy.showChart;
-        graphviz = copy.graphviz;
-        suppressIxmlAmbiguous = copy.suppressIxmlAmbiguous;
-        suppressIxmlPrefix = copy.suppressIxmlPrefix;
-        allowUndefinedSymbols = copy.allowUndefinedSymbols;
-        assertValidXmlNames = copy.assertValidXmlNames;
-    }
-
-    /**
      * Ignore trailing whitespace.
      * <p>If a parse fails where it would have succeeded if trailing whitespace was
      * removed from the input, report success.</p>

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -243,9 +243,7 @@ public class Ixml extends XNonterminal {
     }
 
     private void constructGrammar(ParserOptions options) {
-        ParserOptions localOptions = new ParserOptions(options);
-        localOptions.treesWithStates = true;
-        grammar = new Grammar(localOptions);
+        grammar = new Grammar(options);
 
         ArrayList<ParserAttribute> attributes = new ArrayList<>();
         for (XNode child : children) {

--- a/src/test/java/org/nineml/coffeefilter/TestReport.java
+++ b/src/test/java/org/nineml/coffeefilter/TestReport.java
@@ -1,0 +1,101 @@
+package org.nineml.coffeefilter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class TestReport {
+    private int testsToRun = 0;
+    private int testsSkipped = 0;
+    private int passed = 0;
+    private final ArrayList<TestResult> results = new ArrayList<>();
+    private final HashSet<Integer> timers = new HashSet<>();
+    private final HashMap<Integer, String> messages = new HashMap<>();
+
+    public void toRun(int toRun) {
+        testsToRun = toRun;
+        System.err.println("Tests to run: " + toRun);
+    }
+
+    public void toSkip(int toSkip) {
+        testsSkipped = toSkip;
+        System.err.println("Tests skipped: " + toSkip);
+    }
+
+    public boolean passedAll() {
+        return passed == testsToRun;
+    }
+
+    public int getPassed() {
+        return passed;
+    }
+
+    public int getTotal() {
+        return testsToRun;
+    }
+
+    public int getSkipped() {
+        return testsSkipped;
+    }
+
+    public void start(int count, String name, String setName) {
+        while (results.size() <= count) {
+            results.add(null);
+        }
+
+        if (name == null) {
+            messages.put(count, String.format("Running test %d of %d (from %s):", count, testsToRun, setName));
+        } else {
+            messages.put(count, String.format("Running %s, test %d of %d:", name, count, testsToRun));
+        }
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException ex) {
+                    // nop
+                }
+
+                if (results.get(count) == null) {
+                    timers.add(count);
+                    System.err.println(messages.get(count));
+                }
+            }
+        }).start();
+    }
+
+    public void result(int count, TestResult result) {
+        results.set(count, result);
+        if (result != null) {
+            if (result.state == TestState.PASS) {
+                passed++;
+                if (timers.contains(count)) {
+                    result.summarize();
+                }
+            } else {
+                if (!timers.contains(count)) {
+                    System.err.println(messages.get(count));
+                }
+
+                if (result.actual != null) {
+                    System.err.println("Actual result:");
+                    System.err.println(result.actual.get(0));
+                }
+
+                for (int pos = 0; pos < result.expected.size(); pos++) {
+                    System.err.println("Expected result:");
+                    System.err.println(result.expected.get(pos));
+                    System.err.println(result.deepEqualMessages.get(pos));
+                }
+
+                result.summarize();;
+            }
+        }
+    }
+
+    public void finished() {
+        System.err.printf("Passed %d of %d tests.%n", passed, testsToRun);
+    }
+}

--- a/src/test/java/org/nineml/coffeefilter/TestResult.java
+++ b/src/test/java/org/nineml/coffeefilter/TestResult.java
@@ -1,0 +1,54 @@
+package org.nineml.coffeefilter;
+
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmValue;
+
+import java.util.ArrayList;
+
+public class TestResult {
+    public final XdmNode testCase;
+    public long grammarParseTime = -1;
+    public long documentParseTime = -1;
+    public TestState state = TestState.UNKNOWN;
+    public String xml = null;
+
+    public ArrayList<XdmValue> expected = null;
+    public ArrayList<XdmValue> actual = null;
+    public ArrayList<String> deepEqualMessages = null;
+
+    public TestResult(XdmNode testCase) {
+        this.testCase = testCase;
+    }
+
+    public void summarize() {
+        StringBuilder sb = new StringBuilder();
+        switch (state) {
+            case FAIL:
+                sb.append("FAIL: ");
+                break;
+            case PASS:
+                sb.append("Pass: ");
+                break;
+            default:
+                sb.append("\t??? Unknown: ");
+        }
+        if (grammarParseTime >= 0) {
+            sb.append("parsed grammar in ").append(time(grammarParseTime));
+            if (documentParseTime >= 0) {
+                sb.append("; ");
+            } else {
+                sb.append(".");
+            }
+        }
+        if (documentParseTime >= 0) {
+            sb.append("parsed document in ").append(time(documentParseTime));
+            sb.append(".");
+        }
+        System.err.println(sb);
+        System.err.println("------------------------------------------------------------");
+    }
+
+    private String time(long duration) {
+        return String.format("%5.3fs", duration / 1000.0);
+    }
+}

--- a/src/test/java/org/nineml/coffeefilter/TestState.java
+++ b/src/test/java/org/nineml/coffeefilter/TestState.java
@@ -1,0 +1,7 @@
+package org.nineml.coffeefilter;
+
+public enum TestState {
+    UNKNOWN,
+    PASS,
+    FAIL
+}


### PR DESCRIPTION
On my way to supporting an XML report format, I made a number of improvements to the test report output. Tests that run quickly and pass aren't mentioned at all. Tests that fail include a description of what went wrong.

I also removed the copy constructor from `ParserOptions`, see https://github.com/nineml/coffeegrinder/pull/40