### PR TITLE
Grammar compiler improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.8.0
+filterVersion=0.8.1
 
 grinderName=coffeegrinder
-grinderVersion=0.8.0
+grinderVersion=0.8.2
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URLConnection;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * A parser for a particular Invisible XML grammar.
@@ -51,6 +52,7 @@ public class InvisibleXmlParser {
 
     /**
      * Get the parser options.
+     *
      * @return the parser options
      */
     public ParserOptions getOptions() {
@@ -59,6 +61,7 @@ public class InvisibleXmlParser {
 
     /**
      * Set the parser options.
+     *
      * @param options the parser options
      */
     public void setOptions(ParserOptions options) {
@@ -69,6 +72,7 @@ public class InvisibleXmlParser {
      * Return the exception that caused an attempt to build a parser to fail.
      * <p>If the attempt was successful, or if failure did not raise an exception, <code>null</code>
      * will be returned.</p>
+     *
      * @return the exception, or null if no exception is available
      */
     public Exception getException() {
@@ -79,6 +83,7 @@ public class InvisibleXmlParser {
      * Get the time spent parsing the input grammar.
      * <p>This returns the number of milliseconds of "wall clock time" spent by the processor
      * constructing this parser.</p>
+     *
      * @return the time in milliseconds
      */
     public long getParseTime() {
@@ -87,6 +92,7 @@ public class InvisibleXmlParser {
 
     /**
      * Did the grammar parse succeed?
+     *
      * @return true if the parse succeeded
      */
     public boolean constructed() {
@@ -95,6 +101,7 @@ public class InvisibleXmlParser {
 
     /**
      * Get the hygiene report for this parser's grammar
+     *
      * @return the hygiene report
      */
     public HygieneReport getHygieneReport() {
@@ -106,6 +113,7 @@ public class InvisibleXmlParser {
 
     /**
      * If the attempt to parse the grammar failed, return a representation of that failure.
+     *
      * @return The failed parse, or null if the parse succeeded.
      */
     public InvisibleXmlDocument getFailedParse() {
@@ -116,9 +124,10 @@ public class InvisibleXmlParser {
      * Get a document from a URI.
      * <p>Attempts to read from the URI with <code>source.toURL().openConnection()</code>.
      * Assumes the input is in UTF-8.</p>
+     *
      * @param source the source
      * @return a document
-     * @throws IOException If the source cannot be read
+     * @throws IOException          If the source cannot be read
      * @throws NullPointerException if this parser has no grammar
      */
     public InvisibleXmlDocument parse(URI source) throws IOException {
@@ -128,9 +137,10 @@ public class InvisibleXmlParser {
     /**
      * Get a document from a file.
      * <p>Assumes the input is in UTF-8.</p>
+     *
      * @param source the source
      * @return a document
-     * @throws IOException If the source cannot be read
+     * @throws IOException          If the source cannot be read
      * @throws NullPointerException if this parser has no grammar
      */
     public InvisibleXmlDocument parse(File source) throws IOException {
@@ -141,10 +151,11 @@ public class InvisibleXmlParser {
      * Get a document from a URI with an explicit encoding.
      * <p>Attempts to read from the URI with <code>source.toURL().openConnection()</code>.
      * </p>
-     * @param source the source
+     *
+     * @param source   the source
      * @param encoding the encoding
      * @return a document
-     * @throws IOException If the stream cannot be read or if the character set is unsupported.
+     * @throws IOException          If the stream cannot be read or if the character set is unsupported.
      * @throws NullPointerException if this parser has no grammar
      */
     public InvisibleXmlDocument parse(URI source, String encoding) throws IOException {
@@ -155,10 +166,11 @@ public class InvisibleXmlParser {
 
     /**
      * Get a document from a file with an explicit encoding.
-     * @param source the source
+     *
+     * @param source   the source
      * @param encoding the encoding
      * @return a document
-     * @throws IOException If the stream cannot be read or if the character set is unsupported.
+     * @throws IOException          If the stream cannot be read or if the character set is unsupported.
      * @throws NullPointerException if this parser has no grammar
      */
     public InvisibleXmlDocument parse(File source, String encoding) throws IOException {
@@ -167,10 +179,11 @@ public class InvisibleXmlParser {
 
     /**
      * Get a document from a stream.
-     * @param stream The input.
+     *
+     * @param stream   The input.
      * @param encoding The input encoding.
      * @return A document.
-     * @throws IOException If the stream cannot be read or if the character set is unsupported.
+     * @throws IOException          If the stream cannot be read or if the character set is unsupported.
      * @throws NullPointerException if this parser has no grammar
      */
     public InvisibleXmlDocument parse(InputStream stream, String encoding) throws IOException {
@@ -187,6 +200,7 @@ public class InvisibleXmlParser {
 
     /**
      * Get a document from a string.
+     *
      * @param input The input.
      * @return A document.
      * @throws NullPointerException if this parser has no grammar
@@ -220,16 +234,28 @@ public class InvisibleXmlParser {
     }
 
     /**
-     * Get a string representation of the compiled grammar
+     * Get a string representation of the compiled grammar.
      * @return the XML serialization of the compiled grammar
      * @throws NullPointerException if this parser has no grammar
      */
     public String getCompiledParser() {
+        return getCompiledParser(null);
+    }
+
+    /**
+     * Get a string representation of the compiled grammar.
+     * <p>If an empty map, or null, is passed in for the properties, no extra properties
+     * are added to the compiled grammar.</p>
+     * @param properties extra properties to store in the compiled grammar
+     * @return the XML serialization of the compiled grammar
+     * @throws NullPointerException if this parser has no grammar
+     */
+    public String getCompiledParser(Map<String,String> properties) {
         if (ixml == null) {
             throw new NullPointerException("No grammar for this parser");
         }
         IxmlCompiler compiler = new IxmlCompiler();
-        return compiler.compile(ixml.getGrammar(options));
+        return compiler.compile(ixml.getGrammar(options), properties);
     }
 
     /**

--- a/src/main/java/org/nineml/coffeefilter/model/IxmlCompiler.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IxmlCompiler.java
@@ -5,18 +5,53 @@ import org.nineml.coffeegrinder.util.GrammarCompiler;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
+/**
+ * An API to compiled grammars.
+ */
 public class IxmlCompiler {
+    /**
+     * Compile a grammar.
+     * @param grammar the grammar
+     * @return the compiled grammar
+     */
     public String compile(Grammar grammar) {
+        return compile(grammar, null);
+    }
+
+    /**
+     * Compile a grammar.
+     * @param grammar the grammar
+     * @param properties the properties to store in that grammar
+     * @return the compiled grammar
+     */
+    public String compile(Grammar grammar, Map<String,String> properties) {
         GrammarCompiler compiler = new GrammarCompiler();
+        if (properties != null) {
+            for (String name : properties.keySet()) {
+                compiler.setProperty(name, properties.get(name));
+            }
+        }
         return compiler.compile(grammar);
     }
 
+    /**
+     * Parse a compiled grammar.
+     * @param compiled the compiled grammar
+     * @return the Ixml parser
+     * @throws IOException if the file cannot be read
+     */
     public Ixml parse(File compiled) throws IOException {
         GrammarCompiler compiler = new GrammarCompiler();
         return new Ixml(compiler.parse(compiled));
     }
 
+    /**
+     * Parse a compiled grammar
+     * @param input the compiled grammar
+     * @return the Ixml parser
+     */
     public Ixml parse(String input) {
         GrammarCompiler compiler = new GrammarCompiler();
         return new Ixml(compiler.parse(input));

--- a/src/test/java/org/nineml/coffeefilter/CompiledGrammarTest.java
+++ b/src/test/java/org/nineml/coffeefilter/CompiledGrammarTest.java
@@ -2,9 +2,7 @@ package org.nineml.coffeefilter;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.nineml.coffeefilter.InvisibleXml;
-import org.nineml.coffeefilter.InvisibleXmlDocument;
-import org.nineml.coffeefilter.InvisibleXmlParser;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -13,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.fail;
 
 public class CompiledGrammarTest {
-    private static InvisibleXml invisibleXml = new InvisibleXml();
+    private static final InvisibleXml invisibleXml = new InvisibleXml();
 
     @Test
     public void parseIxmlGrammar() {
@@ -42,17 +40,33 @@ public class CompiledGrammarTest {
         try {
             InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/correct/hash.ixml"));
             InvisibleXmlDocument doc = parser.parse("#12.");
-            //doc.getEarleyResult().getForest().parse().serialize("hash.xml");
-            //doc.getEarleyResult().getForest().serialize("graph.xml");
+            Assertions.assertTrue(doc.succeeded());
             String compiled = parser.getCompiledParser();
-            //System.err.println(compiled);
 
             ByteArrayInputStream bais = new ByteArrayInputStream(compiled.getBytes(StandardCharsets.UTF_8));
 
             parser = invisibleXml.getParser(bais, null);
             doc = parser.parse("#12.");
-            //doc.getEarleyResult().getForest().parse().serialize("hash2.xml");
-            //doc.getEarleyResult().getForest().serialize("graph2.xml");
+            Assertions.assertTrue(doc.succeeded());
+            String recompiled = parser.getCompiledParser();
+
+            Assertions.assertEquals(compiled, recompiled);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void compiledGrammarBug() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/bad-compiled.ixml"));
+            String compiled = parser.getCompiledParser();
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(compiled.getBytes(StandardCharsets.UTF_8));
+            InvisibleXmlParser parser2 = invisibleXml.getParser(bais, null);
+            String recompiled = parser2.getCompiledParser();
+
+            Assertions.assertEquals(compiled, recompiled);
         } catch (Exception ex) {
             fail();
         }

--- a/src/test/resources/bad-compiled.ixml
+++ b/src/test/resources/bad-compiled.ixml
@@ -1,0 +1,9 @@
+phone-number: (areacode, sep)?, prefix, sep, number .
+sep: dash, space .
+dash: '-'? .
+space: ' '? .
+number: digits .
+prefix: digits .
+areacode: digits .
+digits: ['0'-'9']+ .
+

--- a/tools/docbook.xsl
+++ b/tools/docbook.xsl
@@ -16,7 +16,7 @@
 <xsl:import href="../website/docbook.xsl"/>
 
 <xsl:param name="css-links"
-           select="'css/docbook.css css/docbook-screen.css css/nineml.css css/coffeegrinder.css'"/>
+           select="'css/docbook.css css/docbook-screen.css css/nineml.css css/coffeefilter.css'"/>
 
 <!-- ============================================================ -->
 


### PR DESCRIPTION
1. Use the bug-fixed version 0.8.2 CoffeeGrinder
2. Document the `IxmlCompiler` object; add methods to support passing properties to the compiler.

The properties are just metadata.
