### PR TITLE
Make sure that marks are not lost on terminals

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ filterTitle=CoffeeFilter
 filterVersion=0.9.0
 
 grinderName=coffeegrinder
-grinderVersion=0.8.2
+grinderVersion=0.9.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.8.1
+filterVersion=0.9.0
 
 grinderName=coffeegrinder
 grinderVersion=0.8.2

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -239,23 +239,11 @@ public class InvisibleXmlParser {
      * @throws NullPointerException if this parser has no grammar
      */
     public String getCompiledParser() {
-        return getCompiledParser(null);
-    }
-
-    /**
-     * Get a string representation of the compiled grammar.
-     * <p>If an empty map, or null, is passed in for the properties, no extra properties
-     * are added to the compiled grammar.</p>
-     * @param properties extra properties to store in the compiled grammar
-     * @return the XML serialization of the compiled grammar
-     * @throws NullPointerException if this parser has no grammar
-     */
-    public String getCompiledParser(Map<String,String> properties) {
         if (ixml == null) {
             throw new NullPointerException("No grammar for this parser");
         }
         IxmlCompiler compiler = new IxmlCompiler();
-        return compiler.compile(ixml.getGrammar(options), properties);
+        return compiler.compile(ixml.getGrammar(options));
     }
 
     /**

--- a/src/main/java/org/nineml/coffeefilter/model/Charset.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Charset.java
@@ -2,6 +2,7 @@ package org.nineml.coffeefilter.model;
 
 import org.nineml.coffeegrinder.parser.TerminalSymbol;
 import org.nineml.coffeegrinder.tokens.CharacterSet;
+import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacterSet;
 import org.nineml.coffeegrinder.util.ParserAttribute;
 
@@ -47,20 +48,6 @@ public abstract class Charset extends XTerminal implements TMarked {
      */
     public char getTMark() {
         return tmark;
-    }
-
-    /**
-     * Return the terminal symbol that matches this terminal.
-     * @return The symbol.
-     */
-    @Override
-    public TerminalSymbol getTerminal() {
-        if (symbol == null) {
-            ArrayList<ParserAttribute> attributes = new ArrayList<>();
-            attributes.add(new ParserAttribute("tmark", ""+getTMark()));
-            symbol = new TerminalSymbol(TokenCharacterSet.inclusion(getCharacterSets()), attributes);
-        }
-        return symbol;
     }
 
     /**

--- a/src/main/java/org/nineml/coffeefilter/model/IExclusion.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IExclusion.java
@@ -1,7 +1,7 @@
 package org.nineml.coffeefilter.model;
 
-import org.nineml.coffeegrinder.parser.TerminalSymbol;
 import org.nineml.coffeegrinder.tokens.CharacterSet;
+import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacterSet;
 
 /**
@@ -31,15 +31,15 @@ public class IExclusion extends Charset {
     }
 
     /**
-     * Return the terminal symbol that matches this exclusion.
-     * @return The symbol.
+     * Return the token that matches this terminal.
+     * <p>This time the token is an exclusion of the underlying character set.</p>
+     * @return the token.
      */
-    @Override
-    public TerminalSymbol getTerminal() {
-        if (symbol == null) {
-            symbol = new TerminalSymbol(TokenCharacterSet.exclusion(getCharacterSets()));
+    public Token getToken() {
+        if (token == null) {
+            token = TokenCharacterSet.exclusion(getCharacterSets());
         }
-        return symbol;
+        return token;
     }
 
     /**
@@ -61,6 +61,9 @@ public class IExclusion extends Charset {
             }
         }
         sb.append("]");
+        if (optional) {
+            sb.append("?");
+        }
         return sb.toString();
     }
 }

--- a/src/main/java/org/nineml/coffeefilter/model/IInclusion.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IInclusion.java
@@ -47,6 +47,9 @@ public class IInclusion extends Charset {
             }
         }
         sb.append("]");
+        if (optional) {
+            sb.append("?");
+        }
         return sb.toString();
     }
 }

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -274,11 +274,7 @@ public class Ixml extends XNonterminal {
                             if (cat.getName().startsWith("$")) {
                                 attributes.add(ParserAttribute.PRUNING_ALLOWED);
                             }
-                            if (cat.isOptional()) {
-                                attributes.add(Symbol.OPTIONAL);
-                            }
                         }
-
 
                         NonterminalSymbol nts = grammar.getNonterminal(nt.getName(), attributes);
                         rhs.add(nts);
@@ -300,7 +296,13 @@ public class Ixml extends XNonterminal {
                         }
                     } else if (cat instanceof XTerminal) {
                         XTerminal term = (XTerminal) cat;
-                        rhs.add(term.getTerminal());
+
+                        if (term instanceof TMarked) {
+                            char mark = ((TMarked) term).getTMark();
+                            attributes.add(new ParserAttribute("tmark", ""+mark));
+                        }
+
+                        rhs.add(new TerminalSymbol(term.getToken(), attributes));
                     } else {
                         throw new RuntimeException("Unexpected category: " + cat.getName());
                     }

--- a/src/main/java/org/nineml/coffeefilter/model/IxmlCompiler.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IxmlCompiler.java
@@ -17,22 +17,7 @@ public class IxmlCompiler {
      * @return the compiled grammar
      */
     public String compile(Grammar grammar) {
-        return compile(grammar, null);
-    }
-
-    /**
-     * Compile a grammar.
-     * @param grammar the grammar
-     * @param properties the properties to store in that grammar
-     * @return the compiled grammar
-     */
-    public String compile(Grammar grammar, Map<String,String> properties) {
         GrammarCompiler compiler = new GrammarCompiler();
-        if (properties != null) {
-            for (String name : properties.keySet()) {
-                compiler.setProperty(name, properties.get(name));
-            }
-        }
         return compiler.compile(grammar);
     }
 

--- a/src/main/java/org/nineml/coffeefilter/model/XTerminal.java
+++ b/src/main/java/org/nineml/coffeefilter/model/XTerminal.java
@@ -1,7 +1,7 @@
 package org.nineml.coffeefilter.model;
 
-import org.nineml.coffeegrinder.parser.TerminalSymbol;
 import org.nineml.coffeegrinder.tokens.CharacterSet;
+import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacterSet;
 
 import java.util.List;
@@ -10,7 +10,7 @@ import java.util.List;
  * An abstract class representing terminal nodes.
  */
 public abstract class XTerminal extends XNode {
-    protected TerminalSymbol symbol = null;
+    protected Token token = null;
 
     /**
      * Construct a terminal.
@@ -23,14 +23,16 @@ public abstract class XTerminal extends XNode {
     }
 
     /**
-     * Return the terminal symbol that matches this terminal.
-     * @return The symbol.
+     * Return the token that matches this terminal.
+     * <p>The default is to match the underlying character sets (strings, ranges, classes, etc.)
+     * as an inclusion.</p>
+     * @return the token.
      */
-    public TerminalSymbol getTerminal() {
-        if (symbol == null) {
-            symbol = new TerminalSymbol(TokenCharacterSet.inclusion(getCharacterSets()));
+    public Token getToken()  {
+        if (token == null) {
+            token = TokenCharacterSet.inclusion(getCharacterSets());
         }
-        return symbol;
+        return token;
     }
 
     /**

--- a/src/test/java/org/nineml/coffeefilter/ParserTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ParserTest.java
@@ -4,6 +4,7 @@ import net.sf.saxon.s9api.*;
 import net.sf.saxon.s9api.DocumentBuilder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
 
@@ -140,6 +141,21 @@ public class ParserTest {
             System.err.println(ex.getMessage());
             fail();
         }
+    }
+
+    @Test
+    public void ambig3() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S: 'a', sep, sep, sep, sep, sep, 'b' .\n" +
+                "sep: ['.';',']? .";
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+
+        input = "a.b";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        Assertions.assertEquals("<S xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:state=\"ambiguous\">a<sep>.</sep><sep/><sep/><sep/><sep/>b</S>",
+                doc.getTree());
     }
 
     @Test

--- a/src/test/resources/test-suite-exceptions
+++ b/src/test/resources/test-suite-exceptions
@@ -1,4 +1,2 @@
 set "expr1"
     case "expr1" because Its output is not valid XML.
-set "xpath"
-    case "xpath" because The performance is so bad.


### PR DESCRIPTION
Fix #37 

This involved an API change. An `XTerminal` now has a `getToken()` method rather than a `getTerminal()` method. The parser combines the token with the appropriate attributes.
