### PR TITLE
Upgrade CoffeeGrinder and bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=0.9.2
+filterVersion=0.10.0
 
 grinderName=coffeegrinder
-grinderVersion=0.9.2
+grinderVersion=0.10.0
 
 xmlresolverVersion=4.1.2
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
@@ -229,7 +229,7 @@ public class InvisibleXml {
             Ixml ixml = new Ixml(options, grammar);
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
             InvisibleXmlParser parser = new InvisibleXmlParser(ixml, parseMillis);
-            parser.setOptions(options);
+            //parser.setOptions(options);
             return parser;
         } catch (CoffeeGrinderException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
@@ -256,7 +256,7 @@ public class InvisibleXml {
             Ixml ixml = handler.getIxml();
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
             InvisibleXmlParser iparser = new InvisibleXmlParser(ixml, parseMillis);
-            iparser.setOptions(options);
+            //iparser.setOptions(options);
             return iparser;
         } catch (ParserConfigurationException|SAXException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
@@ -275,7 +275,7 @@ public class InvisibleXml {
      */
     public InvisibleXmlParser getParserFromIxml(InputStream stream, String charset) throws IOException {
         InvisibleXmlParser ixmlParser = getParser();
-        ixmlParser.setOptions(options);
+        //ixmlParser.setOptions(options);
 
         InvisibleXmlDocument doc = ixmlParser.parse(stream, charset);
         if (doc.getNumberOfParses() == 0) {

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
@@ -284,7 +284,7 @@ public class InvisibleXmlDocument {
                 atomicValue(handler, "permitted", sb.toString());
             }
 
-            if (options.showChart) {
+            if (options.getShowChart()) {
                 handler.startElement("", "chart", "chart", AttributeBuilder.EMPTY_ATTRIBUTES);
 
                 for (int row = 0; row < result.getChart().size(); row++) {

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -217,12 +217,12 @@ public class InvisibleXmlParser {
         EarleyResult result = parser.parse(iterator);
 
         InvisibleXmlDocument doc;
-        if (!result.succeeded() && result.prefixSucceeded() && options.ignoreTrailingWhitespace) {
+        if (!result.succeeded() && result.prefixSucceeded() && options.getIgnoreTrailingWhitespace()) {
             boolean ok = true;
             Iterator<Token> remaining = result.getContinuingIterator();
             while (remaining.hasNext()) {
                 Token token = remaining.next();
-                ok = ok && (token instanceof TokenCharacter) && Character.isWhitespace(((TokenCharacter) token).getValue());
+                ok = ok && (token instanceof TokenCharacter) && Character.isWhitespace(((TokenCharacter) token).getCharacter());
             }
             doc = new InvisibleXmlDocument(result, options, ok);
         } else {

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -23,7 +23,7 @@ public class InvisibleXmlParser {
     private final Ixml ixml;
     private final InvisibleXmlDocument failedParse;
     private final long parseTime;
-    private ParserOptions options = new ParserOptions();
+    private final ParserOptions options;
     private Exception exception = null;
     private HygieneReport hygieneReport = null;
 
@@ -31,18 +31,21 @@ public class InvisibleXmlParser {
         this.ixml = ixml;
         this.parseTime = -1;
         failedParse = null;
+        options = ixml.getOptions();
     }
 
     protected InvisibleXmlParser(Ixml ixml, long parseMillis) {
         this.ixml = ixml;
         this.parseTime = parseMillis;
         failedParse = null;
+        options = ixml.getOptions();
     }
 
     protected InvisibleXmlParser(InvisibleXmlDocument failed, long parseMillis) {
         ixml = null;
         parseTime = parseMillis;
         failedParse = failed;
+        options = failed.getOptions();
     }
 
     protected InvisibleXmlParser(InvisibleXmlDocument failed, Exception exception, long parseMillis) {
@@ -63,10 +66,10 @@ public class InvisibleXmlParser {
      * Set the parser options.
      *
      * @param options the parser options
-     */
     public void setOptions(ParserOptions options) {
         this.options = options;
     }
+     */
 
     /**
      * Return the exception that caused an attempt to build a parser to fail.

--- a/src/main/java/org/nineml/coffeefilter/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeefilter/ParserOptions.java
@@ -1,63 +1,270 @@
 package org.nineml.coffeefilter;
 
+import org.nineml.logging.DefaultLogger;
+import org.nineml.logging.Logger;
+
+import java.util.HashSet;
+
+/**
+ * Options to the Invisible XML processor.
+ * <p>This object is extended by other members of the NineML family to provide additional options.
+ * It started out as a collection of public fields, but changed to a more traditional collection of
+ * getters and setters when it began to develop options that were not entirely independent.</p>
+ */
 public class ParserOptions extends org.nineml.coffeegrinder.parser.ParserOptions {
+    private boolean ignoreTrailingWhitespace = false;
+    private boolean allowUndefinedSymbols = false;
+    private boolean allowUnreachableSymbols = true;
+    private boolean allowUnproductiveSymbols = true;
+    private boolean allowMultipleDefinitions = false;
+    private boolean prettyPrint = false;
+    private boolean showChart = false;
+    private String graphviz = null;
+    private static HashSet<String> suppressedIxmlStates = new HashSet<>();
+    private boolean assertValidXmlNames = true;
+    private boolean pedantic = false;
+
     /**
-     * The default constructor.
-     * <p>This object is intended to be just a collection of publicly modifiable fields.</p>
+     * Create the parser options.
+     * <p>The initial logger will be a {@link DefaultLogger} initialized with
+     * {@link DefaultLogger#readSystemProperties readSystemProperties()}.</p>
      */
     public ParserOptions() {
         super();
     }
 
     /**
-     * Ignore trailing whitespace.
-     * <p>If a parse fails where it would have succeeded if trailing whitespace was
-     * removed from the input, report success.</p>
+     * Create the parser options with an explicit logger.
+     * @param logger the logger.
      */
-    public boolean ignoreTrailingWhitespace = false;
+    public ParserOptions(Logger logger) {
+        super(logger);
+    }
 
     /**
-     * Allow undefined symbols.
+     * Ignore trailing whitespace?
+     * <p>If a parse fails where it would have succeeded if trailing whitespace was
+     * removed from the input, report success.</p>
+     * @return true if trailing whitespace is ignored
+     */
+    public boolean getIgnoreTrailingWhitespace() {
+        return ignoreTrailingWhitespace;
+    }
+
+    /**
+     * Set the {@link #getIgnoreTrailingWhitespace()} property.
+     * @param ignore ignore trailing whitespace?
+     */
+    public void setIgnoreTrailingWhitespace(boolean ignore) {
+        ignoreTrailingWhitespace = ignore;
+    }
+
+    /**
+     * Allow undefined symbols?
      * <p>A grammar with undefined symbols isn't necessarily unusable. But Invisible XML
      * forbids them.</p>
+     * @return true if undefined symbols are allowed
      */
-    public boolean allowUndefinedSymbols = false;
+    public boolean getAllowUndefinedSymbols() {
+        return allowUndefinedSymbols;
+    }
+
+    /**
+     * Set the {@link #getAllowUndefinedSymbols()} property.
+     * <p>Allowing undefined symbols implies {@link #getAllowUnproductiveSymbols()} and
+     * {@link #getAllowUndefinedSymbols()}.
+     * An undefined symbol is always part of an unproductive rule and avoiding errors for
+     * undefined rules often introduces undefined symbols.</p>
+     * @param allow allow undefined symbols?
+     */
+    public void setAllowUndefinedSymbols(boolean allow) {
+        allowUndefinedSymbols = allow;
+        if (allowUndefinedSymbols) {
+            allowUnproductiveSymbols = true;
+        }
+    }
+
+    /**
+     * Allow unreachable symbols?
+     * <p>A grammar with unreachable symbols isn't forbidden by Invisible XML, but might
+     * still be an error.</p>
+     * @return true if unreachable symbols are allowed.
+     */
+    public boolean getAllowUnreachableSymbols() {
+        return allowUnreachableSymbols;
+    }
+
+    /**
+     * Set the {@link #getAllowUnreachableSymbols()} property.
+     * @param allow allow unreachable symbols?
+     */
+    public void setAllowUnreachableSymbols(boolean allow) {
+        allowUnreachableSymbols = allow;
+    }
+
+    /**
+     * Allow unproductive symbols?
+     * <p>An unproductive symbol is one which can never produce output in a valid parse.</p>
+     * @return true if unproductive rules are allowed
+     */
+    public boolean getAllowUnproductiveSymbols() {
+        return allowUnproductiveSymbols;
+    }
+
+    /**
+     * Set the {@link #getAllowUnproductiveSymbols()} property.
+     * @param allow allow unproductive rules?
+     */
+    public void setAllowUnproductiveSymbols(boolean allow) {
+        allowUnproductiveSymbols = allow;
+    }
+
+    /**
+     * Allow multiple definitions?
+     * <p>A grammar with multiply defined symbols isn't a problem for the underlying Earley
+     * parser, but it is forbidden by Invisible XML.</p>
+     * @return true if multiple definitions are allowed.
+     */
+    public boolean getAllowMultipleDefinitions() {
+        return allowMultipleDefinitions;
+    }
+
+    /**
+     * Set the {@link #getAllowMultipleDefinitions()} property.
+     * @param allow allow multiple definitions?
+     */
+    public void setAllowMultipleDefinitions(boolean allow) {
+        allowMultipleDefinitions = allow;
+    }
 
     /**
      * Attempt to pretty print the result?
+     * <p>If the result is pretty printed, extra newlines and spaces for indentation
+     * will be added to the result.</p>
+     * @return true if the result should be pretty printed.
      */
-    public boolean prettyPrint = false;
+    public boolean getPrettyPrint() {
+        return prettyPrint;
+    };
+
+    /**
+     * Set the {@link #getPrettyPrint()} property.
+     * @param prettPrint pretty print?
+     */
+    public void setPrettyPrint(boolean prettPrint) {
+        this.prettyPrint = prettPrint;
+    }
 
     /**
      * Show the Earley chart in error results?
+     * @return true if the early chart should appear in error results.
      */
-    public boolean showChart = false;
+    public boolean getShowChart() {
+        return showChart;
+    };
+
+    /**
+     * Set the {@link #getShowChart()} property.
+     * @param show show the chart?
+     */
+    public void setShowChart(boolean show) {
+        showChart = show;
+    }
 
     /**
      * Where's the GraphViz 'dot' command?
+     * @return the path of the dot command.
      */
-    public String graphviz = null;
+    public String getGraphviz() {
+        return graphviz;
+    };
 
     /**
-     * Suppress the ixml:state=ambiguous annotation on the root element.
+     * Set the {@link #getGraphviz()} property.
+     * <p>Setting the path to <code>null</code> disables SVG output.</p>
+     * @param dot the path to the dot command.
      */
-    public boolean suppressIxmlAmbiguous = false;
+    public void setGraphviz(String dot) {
+        graphviz = dot;
+    }
 
     /**
-     * Suppress the ixml:state=prefix annotation on the root element.
+     * Is the specified state suppressed?
+     * <p>The Invisible XML processor adds state values to the root element to report
+     * conditions such as ambiguity or a prefix parse. These states can be suppressed.</p>
+     * @param state the state
+     * @return true if the state is suppressed.
      */
-    public boolean suppressIxmlPrefix = false;
+    public boolean isSuppressedState(String state) {
+        return suppressedIxmlStates.contains(state);
+    }
+
+    /**
+     * Suppress a state.
+     * <p>The Invisible XML processor adds state values to the root element to report
+     * conditions such as ambiguity or a prefix parse. These states can be suppressed.</p>
+     * @param state the state to suppress.
+     */
+    public void suppressState(String state) {
+        if (!"ambiguous".equals(state) && !"prefix".equals(state)) {
+            getLogger().warn("CoffeeFilter", "Unknown state: %s", state);
+        }
+        suppressedIxmlStates.add(state);
+    }
+
+    /**
+     * Expose a state.
+     * <p>The Invisible XML processor adds state values to the root element to report
+     * conditions such as ambiguity or a prefix parse. These states can be suppressed.</p>
+     * @param state the state to (no longer) suppress
+     */
+    public void exposeState(String state) {
+        if (!"ambiguous".equals(state) && !"prefix".equals(state)) {
+            getLogger().warn("CoffeeFilter", "Unknown state: %s", state);
+        }
+        suppressedIxmlStates.remove(state);
+    }
 
     /**
      * Raise an exception if invalid XML names are used in nonterminals that are serialized.
+     * @return true if invalid XML names should raise an exception
      */
-    public boolean assertValidXmlNames = true;
+    public boolean getAssertValidXmlNames() {
+        return assertValidXmlNames;
+    }
+
+    /**
+     * Set the {@link #getAssertValidXmlNames()} property.
+     * @param valid assert valid names?
+     */
+    public void setAssertValidXmlNames(boolean valid) {
+        assertValidXmlNames = valid;
+    }
 
     /**
      * Enforce strict compliance to the Invisible XML specification.
      * <p>In pedantic mode, the processor won't allow grammar extensions, like pragmas,
      * that are not yet officially incorporated into the specification.</p>
+     * @return true if pedantic mode is enabled
      */
-    public boolean pedantic = false;
+    public boolean getPedantic() {
+        return pedantic;
+    };
 
+    /**
+     * Set the {@link #getPedantic()} property.
+     * <p>In pedantic mode, the processor won't allow grammar extensions, like pragmas,
+     * that are not yet officially incorporated into the specification. Enabling pedantic
+     * mode also resets the allowed grammar hygiene rules to their defaults.</p>
+     * @param pedantic be pedantic?
+     */
+    public void setPedantic(boolean pedantic) {
+        this.pedantic = pedantic;
+        if (pedantic) {
+            allowUndefinedSymbols = false;
+            allowUnreachableSymbols = true;
+            allowUnproductiveSymbols = true;
+            allowMultipleDefinitions = false;
+        }
+    }
 }

--- a/src/main/java/org/nineml/coffeefilter/model/IPragma.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IPragma.java
@@ -20,4 +20,12 @@ public class IPragma extends XNonterminal {
         IPragma prolog = new IPragma(parent, name);
         return prolog;
     }
+
+    @Override
+    public String toString() {
+        if (pragmaData == null) {
+            return "{[" + name + "]}";
+        }
+        return "{[" + name + " " + pragmaData + "]}";
+    }
 }

--- a/src/main/java/org/nineml/coffeefilter/model/IPragmaDiscardEmpty.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IPragmaDiscardEmpty.java
@@ -1,0 +1,8 @@
+package org.nineml.coffeefilter.model;
+
+public class IPragmaDiscardEmpty extends IPragma {
+    public IPragmaDiscardEmpty(XNode parent, String data) {
+        super(parent, "nineml");
+        pragmaData = data;
+    }
+}

--- a/src/main/java/org/nineml/coffeefilter/model/IPragmaRegex.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IPragmaRegex.java
@@ -1,0 +1,8 @@
+package org.nineml.coffeefilter.model;
+
+public class IPragmaRegex extends IPragma {
+    public IPragmaRegex(XNode parent, String data) {
+        super(parent, "nineml");
+        pragmaData = data;
+    }
+}

--- a/src/main/java/org/nineml/coffeefilter/model/IProlog.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IProlog.java
@@ -1,7 +1,5 @@
 package org.nineml.coffeefilter.model;
 
-import java.util.ArrayList;
-
 public class IProlog extends XNonterminal {
 
     public IProlog(XNode parent) {

--- a/src/main/java/org/nineml/coffeefilter/model/ITerminal.java
+++ b/src/main/java/org/nineml/coffeefilter/model/ITerminal.java
@@ -20,6 +20,7 @@ public class ITerminal extends XNonterminal {
     @Override
     public XNode copy() {
         ITerminal newnode = new ITerminal(parent);
+        newnode.pragmas.addAll(pragmas);
         newnode.optional = optional;
         newnode.copyChildren(getChildren());
         return newnode;

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -77,6 +77,14 @@ public class Ixml extends XNonterminal {
     }
 
     /**
+     * Get the parser options for this parser.
+     * @return the parser options.
+     */
+    public ParserOptions getOptions() {
+        return options;
+    }
+
+    /**
      * Copy the current node and its descendants.
      *
      * <p>The parent of the copy is often the same as the original, but

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -121,7 +121,7 @@ public class Ixml extends XNonterminal {
         for (XNode node : children) {
             if (node instanceof IRule) {
                 IRule rule = (IRule) node;
-                if (definedSymbols.contains(rule.getName())) {
+                if (definedSymbols.contains(rule.getName()) && !options.getAllowMultipleDefinitions()) {
                     throw IxmlException.duplicateRuleForSymbol(rule.getName());
                 }
                 definedSymbols.add(rule.getName());
@@ -264,7 +264,15 @@ public class Ixml extends XNonterminal {
                         if (pragma instanceof IPragmaXmlns) {
                             attributes.add(new ParserAttribute("ns", pragma.getPragmaData()));
                         } else {
-                            options.logger.debug(logcategory, "Unknown pragma, or does not apply in the prologue: %s", pragma);
+                            options.getLogger().debug(logcategory, "Unknown pragma, or does not apply in the prologue: %s", pragma);
+                        }
+                    }
+                } else {
+                    for (IPragma pragma : rule.pragmas) {
+                        if (pragma instanceof IPragmaRegex) {
+                            attributes.add(new ParserAttribute("regex", pragma.getPragmaData()));
+                        } else {
+                            options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to rule: %s", pragma);
                         }
                     }
                 }
@@ -286,8 +294,10 @@ public class Ixml extends XNonterminal {
                             for (IPragma pragma : cat.pragmas) {
                                 if (pragma instanceof IPragmaRename) {
                                     attributes.add(new ParserAttribute("name", pragma.getPragmaData()));
+                                } else if (pragma instanceof IPragmaDiscardEmpty) {
+                                    attributes.add(new ParserAttribute("discard", pragma.getPragmaData()));
                                 } else {
-                                    options.logger.debug(logcategory, "Unknown pragma, or does not apply to a nonterminal: %s", pragma);
+                                    options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to a nonterminal: %s", pragma);
                                 }
                             }
                             if (cat.getName().startsWith("$")) {
@@ -307,7 +317,7 @@ public class Ixml extends XNonterminal {
                             if (pragma instanceof IPragmaRewrite) {
                                 rewrite = (IPragmaRewrite) pragma;
                             } else {
-                                options.logger.debug(logcategory, "Unknown pragma, or does not apply to a literal: %s", pragma);
+                                options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to a literal: %s", pragma);
                             }
                         }
 

--- a/src/main/java/org/nineml/coffeefilter/trees/SimpleTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/trees/SimpleTreeBuilder.java
@@ -107,7 +107,7 @@ public class SimpleTreeBuilder extends AbstractTreeBuilder {
             text = null;
         }
 
-        if (options.assertValidXmlNames && !TokenUtils.xmlName(localName)) {
+        if (options.getAssertValidXmlNames() && !TokenUtils.xmlName(localName)) {
             throw IxmlException.invalidXmlName(localName);
         }
 
@@ -115,7 +115,7 @@ public class SimpleTreeBuilder extends AbstractTreeBuilder {
         for (int pos = 0; pos < attributes.getLength(); pos++) {
             String qname = attributes.getQName(pos);
 
-            if (!qname.contains(":") && options.assertValidXmlNames && !TokenUtils.xmlName(qname)) {
+            if (!qname.contains(":") && options.getAssertValidXmlNames() && !TokenUtils.xmlName(qname)) {
                 throw IxmlException.invalidXmlName(qname);
             }
 

--- a/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
@@ -79,7 +79,7 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
             state = START_TAG;
         }
 
-        if (options.prettyPrint) {
+        if (options.getPrettyPrint()) {
             switch (state) {
                 case FIRST:
                     break;
@@ -92,7 +92,7 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
             indent += iunit;
         }
 
-        if (options.assertValidXmlNames && !TokenUtils.xmlName(localName)) {
+        if (options.getAssertValidXmlNames() && !TokenUtils.xmlName(localName)) {
             throw IxmlException.invalidXmlName(localName);
         }
 
@@ -111,7 +111,7 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
             if (qname.contains(":")) {
                 stream.printf("xmlns:%s=\"%s\" ", qname.substring(0, qname.indexOf(":")), attributes.getURI(pos));
             } else {
-                if (options.assertValidXmlNames && !TokenUtils.xmlName(qname)) {
+                if (options.getAssertValidXmlNames() && !TokenUtils.xmlName(qname)) {
                     throw IxmlException.invalidXmlName(qname);
                 }
             }
@@ -134,7 +134,7 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
             stream.print("/>");
         }
 
-        if (options.prettyPrint) {
+        if (options.getPrettyPrint()) {
             if (indent.length() >= iunit.length()) {
                 indent = indent.substring(iunit.length());
             }

--- a/src/main/java/org/nineml/coffeefilter/utils/AttributeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/AttributeBuilder.java
@@ -37,7 +37,7 @@ public final class AttributeBuilder implements Attributes {
             /* Allow them if they're the same value? Not per the current spec...
             int pos = getIndex(ns, name);
             if (value.equals(getValue(pos))) {
-                options.logger.debug(logcategory, "Duplicated attribute: %s", name);
+                options.getLogger().debug(logcategory, "Duplicated attribute: %s", name);
             } else {
                 throw IxmlException.repeatedAttribute(name);
             }

--- a/src/main/resources/org/nineml/coffeefilter/pragmas.cxml
+++ b/src/main/resources/org/nineml/coffeefilter/pragmas.cxml
@@ -1,293 +1,294 @@
 <grammar xmlns="http://nineml.org/coffeegrinder/ns/grammar/compiled" version="0.9.2">
-<meta name='coffeepot-version' value='0.9.1'/>
-<meta name='date' value='2022-03-13T11:34:49Z'/>
+<meta name='coffeepot-version' value='0.10.0'/>
+<meta name='date' value='2022-03-16T08:04:33Z'/>
 <meta name='uri' value='file:/Volumes/Projects/nineml/filter/src/main/resources/org/nineml/coffeefilter/pragmas.ixml'/>
 <ag xml:id="g1" name="$$" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
 <ag xml:id="g2" mark="^"/>
 <r n="$$" a="p" ag="g1"><nt n="ixml" ag="g2"/></r>
 <ag xml:id="g3" name="ixml" mark="^"/>
-<ag xml:id="g4" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<ag xml:id="g5" mark="-"/>
-<r n="ixml" ag="g3"><nt n="prolog" ag="g2"/><nt n="$6" a="p" ag="g4"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g6" name="prolog" mark="^"/>
-<ag xml:id="g7" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="prolog" ag="g6"><nt n="s" ag="g5"/><nt n="$42_option" a="?p" ag="g7"/></r>
-<ag xml:id="g8" name="ppragma" mark="-"/>
-<ag xml:id="g9" tmark="-"/>
-<ag xml:id="g10"/>
-<r n="ppragma" ag="g8"><nt n="pragma" ag="g2"/><nt n="s" ag="g5"/><t ag="g9"><c ag="g10" v="."/></t></r>
-<ag xml:id="g11" name="s" mark="-"/>
-<r n="s" ag="g11"><nt n="$24" a="?p" ag="g7"/></r>
-<ag xml:id="g12" name="whitespace" mark="-"/>
-<r n="whitespace" ag="g12"><t ag="g9"><cs ag="g10" inclusion="Zs"/></t></r>
-<r n="whitespace" ag="g12"><nt n="tab" ag="g5"/></r>
-<r n="whitespace" ag="g12"><nt n="lf" ag="g5"/></r>
-<r n="whitespace" ag="g12"><nt n="cr" ag="g5"/></r>
-<ag xml:id="g13" name="tab" mark="-"/>
-<r n="tab" ag="g13"><t ag="g9"><c ag="g10" v="&#x9;"/></t></r>
-<ag xml:id="g14" name="lf" mark="-"/>
-<r n="lf" ag="g14"><t ag="g9"><c ag="g10" v="&#xa;"/></t></r>
-<ag xml:id="g15" name="cr" mark="-"/>
-<r n="cr" ag="g15"><t ag="g9"><c ag="g10" v="&#xd;"/></t></r>
-<ag xml:id="g16" name="comment" mark="^"/>
-<r n="comment" ag="g16"><t ag="g9"><c ag="g10" v="{"/></t><nt n="$43_option" a="?p" ag="g7"/><t ag="g9"><c ag="g10" v="}"/></t></r>
-<ag xml:id="g17" name="cchar" mark="-"/>
-<ag xml:id="g18" tmark="^"/>
-<r n="cchar" ag="g17"><t ag="g18"><cs ag="g10" exclusion="&quot;{}&quot;"/></t></r>
-<ag xml:id="g19" name="rule" mark="^"/>
-<ag xml:id="g20" mark="@"/>
-<r n="rule" ag="g19"><nt n="annotation" ag="g5"/><nt n="name" ag="g20"/><nt n="s" ag="g5"/><t ag="g9"><cs ag="g10" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g5"/><nt n="alts" ag="g5"/><nt n="$44_option" a="?p" ag="g7"/><t ag="g9"><c ag="g10" v="."/></t></r>
-<ag xml:id="g21" name="mark" mark="@"/>
-<r n="mark" ag="g21"><t ag="g18"><cs ag="g10" inclusion="&quot;@-^&quot;"/></t></r>
-<ag xml:id="g22" name="alts" mark="^"/>
-<r n="alts" ag="g22"><nt n="$12" a="p" ag="g4"/></r>
-<ag xml:id="g23" name="alt" mark="^"/>
-<r n="alt" ag="g23"><nt n="$28" a="p" ag="g4"/></r>
-<ag xml:id="g24" name="term" mark="-"/>
-<r n="term" ag="g24"><nt n="factor" ag="g5"/></r>
-<r n="term" ag="g24"><nt n="option" ag="g2"/></r>
-<r n="term" ag="g24"><nt n="repeat0" ag="g2"/></r>
-<r n="term" ag="g24"><nt n="repeat1" ag="g2"/></r>
-<ag xml:id="g25" name="factor" mark="-"/>
-<r n="factor" ag="g25"><nt n="terminal" ag="g5"/></r>
-<r n="factor" ag="g25"><nt n="nonterminal" ag="g2"/></r>
-<r n="factor" ag="g25"><t ag="g9"><c ag="g10" v="("/></t><nt n="s" ag="g5"/><nt n="alts" ag="g2"/><t ag="g9"><c ag="g10" v=")"/></t><nt n="s" ag="g5"/></r>
-<ag xml:id="g26" name="repeat0" mark="^"/>
-<ag xml:id="g27" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="^"/>
-<r n="repeat0" ag="g26"><nt n="factor" ag="g5"/><t ag="g9"><c ag="g10" v="*"/></t><nt n="s" ag="g5"/><nt n="sep" a="?" ag="g27"/></r>
-<ag xml:id="g28" name="repeat1" mark="^"/>
-<r n="repeat1" ag="g28"><nt n="factor" ag="g5"/><t ag="g9"><c ag="g10" v="+"/></t><nt n="s" ag="g5"/><nt n="sep" a="?" ag="g27"/></r>
-<ag xml:id="g29" name="option" mark="^"/>
-<r n="option" ag="g29"><nt n="factor" ag="g5"/><t ag="g9"><c ag="g10" v="?"/></t><nt n="s" ag="g5"/></r>
-<ag xml:id="g30" name="sep" mark="^"/>
-<r n="sep" ag="g30"><nt n="factor" ag="g5"/></r>
-<ag xml:id="g31" name="nonterminal" mark="^"/>
-<r n="nonterminal" ag="g31"><nt n="annotation" ag="g5"/><nt n="name" ag="g20"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g32" name="annotation" mark="-"/>
-<r n="annotation" ag="g32"><nt n="$45_option" a="?p" ag="g7"/><nt n="$46_option" a="?p" ag="g7"/></r>
-<ag xml:id="g33" name="sp" mark="-"/>
-<r n="sp" ag="g33"><nt n="$32" a="?p" ag="g7"/></r>
-<ag xml:id="g34" name="terminal" mark="-"/>
-<r n="terminal" ag="g34"><nt n="literal" ag="g2"/></r>
-<r n="terminal" ag="g34"><nt n="charset" ag="g5"/></r>
-<ag xml:id="g35" name="literal" mark="^"/>
-<r n="literal" ag="g35"><nt n="quoted" ag="g5"/></r>
-<r n="literal" ag="g35"><nt n="encoded" ag="g5"/></r>
-<ag xml:id="g36" name="quoted" mark="-"/>
-<r n="quoted" ag="g36"><nt n="tannotation" ag="g5"/><nt n="string" ag="g20"/></r>
-<ag xml:id="g37" name="name" mark="@"/>
-<r n="name" ag="g37"><nt n="namestart" ag="g5"/><nt n="$34" a="?p" ag="g7"/></r>
-<ag xml:id="g38" name="namestart" mark="-"/>
-<r n="namestart" ag="g38"><t ag="g18"><cs ag="g10" inclusion="&quot;_&quot;;L"/></t></r>
-<ag xml:id="g39" name="namefollower" mark="-"/>
-<r n="namefollower" ag="g39"><nt n="namestart" ag="g5"/></r>
-<r n="namefollower" ag="g39"><t ag="g18"><cs ag="g10" inclusion="&quot;⁀·-.‿&quot;;Nd;Mn"/></t></r>
-<ag xml:id="g40" name="tannotation" mark="-"/>
-<r n="tannotation" ag="g40"><nt n="$47_option" a="?p" ag="g7"/><nt n="$48_option" a="?p" ag="g7"/></r>
-<ag xml:id="g41" name="tmark" mark="@"/>
-<r n="tmark" ag="g41"><t ag="g18"><cs ag="g10" inclusion="&quot;-^&quot;"/></t></r>
-<ag xml:id="g42" name="string" mark="@"/>
-<r n="string" ag="g42"><t ag="g9"><c ag="g10" v="&quot;"/></t><nt n="$15" a="p" ag="g4"/><t ag="g9"><c ag="g10" v="&quot;"/></t><nt n="s" ag="g5"/></r>
-<r n="string" ag="g42"><t ag="g9"><c ag="g10" v="'"/></t><nt n="$18" a="p" ag="g4"/><t ag="g9"><c ag="g10" v="'"/></t><nt n="s" ag="g5"/></r>
-<ag xml:id="g43" name="dchar" mark="^"/>
-<r n="dchar" ag="g43"><t ag="g18"><cs ag="g10" exclusion="&quot;&amp;quot;&quot;;'&#xa;';'&#xd;'"/></t></r>
-<r n="dchar" ag="g43"><t ag="g18"><c ag="g10" v="&quot;"/></t><t ag="g9"><c ag="g10" v="&quot;"/></t></r>
-<ag xml:id="g44" name="schar" mark="^"/>
-<r n="schar" ag="g44"><t ag="g18"><cs ag="g10" exclusion="&quot;'&quot;;'&#xa;';'&#xd;'"/></t></r>
-<r n="schar" ag="g44"><t ag="g18"><c ag="g10" v="'"/></t><t ag="g9"><c ag="g10" v="'"/></t></r>
-<ag xml:id="g45" name="encoded" mark="-"/>
-<r n="encoded" ag="g45"><nt n="tannotation" ag="g5"/><t ag="g9"><c ag="g10" v="#"/></t><nt n="hex" ag="g20"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g46" name="hex" mark="^"/>
-<r n="hex" ag="g46"><nt n="$21" a="p" ag="g4"/></r>
-<ag xml:id="g47" name="charset" mark="-"/>
-<r n="charset" ag="g47"><nt n="inclusion" ag="g2"/></r>
-<r n="charset" ag="g47"><nt n="exclusion" ag="g2"/></r>
-<ag xml:id="g48" name="inclusion" mark="^"/>
-<r n="inclusion" ag="g48"><nt n="tannotation" ag="g5"/><nt n="set" ag="g5"/></r>
-<ag xml:id="g49" name="exclusion" mark="^"/>
-<r n="exclusion" ag="g49"><nt n="tannotation" ag="g5"/><t ag="g9"><c ag="g10" v="~"/></t><nt n="s" ag="g5"/><nt n="set" ag="g5"/></r>
-<ag xml:id="g50" name="set" mark="-"/>
-<r n="set" ag="g50"><t ag="g9"><c ag="g10" v="["/></t><nt n="s" ag="g5"/><nt n="$36" a="p" ag="g4"/><t ag="g9"><c ag="g10" v="]"/></t><nt n="s" ag="g5"/></r>
-<ag xml:id="g51" name="member" mark="-"/>
-<r n="member" ag="g51"><nt n="literal" ag="g2"/></r>
-<r n="member" ag="g51"><nt n="range" ag="g2"/></r>
-<r n="member" ag="g51"><nt n="class" ag="g2"/></r>
-<ag xml:id="g52" name="range" mark="^"/>
-<r n="range" ag="g52"><nt n="from" ag="g20"/><nt n="s" ag="g5"/><t ag="g9"><c ag="g10" v="-"/></t><nt n="s" ag="g5"/><nt n="to" ag="g20"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g53" name="from" mark="@"/>
-<r n="from" ag="g53"><nt n="character" ag="g5"/></r>
-<ag xml:id="g54" name="to" mark="@"/>
-<r n="to" ag="g54"><nt n="character" ag="g5"/></r>
-<ag xml:id="g55" name="character" mark="-"/>
-<r n="character" ag="g55"><t ag="g9"><c ag="g10" v="&quot;"/></t><nt n="dchar" ag="g2"/><t ag="g9"><c ag="g10" v="&quot;"/></t></r>
-<r n="character" ag="g55"><t ag="g9"><c ag="g10" v="'"/></t><nt n="schar" ag="g2"/><t ag="g9"><c ag="g10" v="'"/></t></r>
-<r n="character" ag="g55"><t ag="g18"><c ag="g10" v="#"/></t><nt n="hex" ag="g2"/></r>
-<ag xml:id="g56" name="class" mark="^"/>
-<r n="class" ag="g56"><nt n="code" ag="g20"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g57" name="code" mark="@"/>
-<ag xml:id="g58" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="-"/>
-<r n="code" ag="g57"><nt n="capital" ag="g5"/><nt n="letter" a="?" ag="g58"/></r>
-<ag xml:id="g59" name="capital" mark="-"/>
-<r n="capital" ag="g59"><t ag="g18"><cs ag="g10" inclusion="'A'-'Z'"/></t></r>
-<ag xml:id="g60" name="letter" mark="-"/>
-<r n="letter" ag="g60"><t ag="g18"><cs ag="g10" inclusion="'a'-'z'"/></t></r>
-<ag xml:id="g61" name="pragma" mark="^"/>
-<ag xml:id="g62" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="@"/>
-<r n="pragma" ag="g61"><nt n="pld" ag="g5"/><nt n="pmark" a="?" ag="g62"/><nt n="name" ag="g20"/><nt n="$49_option" a="?p" ag="g7"/><nt n="prd" ag="g5"/></r>
-<ag xml:id="g63" name="pmark" mark="@"/>
-<r n="pmark" ag="g63"><t ag="g18"><cs ag="g10" inclusion="&quot;@^?&quot;"/></t></r>
-<ag xml:id="g64" name="pragma-data" mark="^"/>
-<r n="pragma-data" ag="g64"><nt n="$40" a="?p" ag="g7"/></r>
-<ag xml:id="g65" name="pragma-char" mark="-"/>
-<r n="pragma-char" ag="g65"><t ag="g18"><cs ag="g10" exclusion="&quot;{}&quot;"/></t></r>
-<ag xml:id="g66" name="bracket-pair" mark="-"/>
-<r n="bracket-pair" ag="g66"><t ag="g18"><c ag="g10" v="{"/></t><nt n="pragma-data" ag="g5"/><t ag="g18"><c ag="g10" v="}"/></t></r>
-<ag xml:id="g67" name="pld" mark="-"/>
-<r n="pld" ag="g67"><t ag="g9"><c ag="g10" v="{"/></t><t ag="g9"><c ag="g10" v="["/></t></r>
-<ag xml:id="g68" name="prd" mark="-"/>
-<r n="prd" ag="g68"><t ag="g9"><c ag="g10" v="]"/></t><t ag="g9"><c ag="g10" v="}"/></t></r>
-<ag xml:id="g69" name="|$1" mark="-"/>
-<r n="|$1" ag="g69"><nt n="whitespace" ag="g5"/></r>
-<r n="|$1" ag="g69"><nt n="comment" ag="g2"/></r>
-<ag xml:id="g70" name="|$2" mark="-"/>
-<r n="|$2" ag="g70"><nt n="cchar" ag="g5"/></r>
-<r n="|$2" ag="g70"><nt n="comment" ag="g2"/></r>
-<ag xml:id="g71" name="|$3" mark="-"/>
-<r n="|$3" ag="g71"><nt n="comment" ag="g2"/></r>
-<r n="|$3" ag="g71"><t ag="g18"><cs ag="g10" exclusion="'[';']';&quot;{}&quot;"/></t></r>
-<ag xml:id="g72" name="|$4" mark="-"/>
-<r n="|$4" ag="g72"><nt n="whitespace" ag="g5"/></r>
-<r n="|$4" ag="g72"><nt n="comment" ag="g2"/></r>
-<r n="|$4" ag="g72"><nt n="pragma" ag="g2"/></r>
-<ag xml:id="g73" name="|$5" mark="-"/>
-<r n="|$5" ag="g73"><nt n="pragma-char" ag="g5"/></r>
-<r n="|$5" ag="g73"><nt n="bracket-pair" ag="g5"/></r>
-<ag xml:id="g74" name="$6" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$6" a="p" ag="g74"><nt n="rule" ag="g2"/><nt n="$7" a="?p" ag="g7"/></r>
-<ag xml:id="g75" name="$7" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$7" a="p" ag="g75"><nt n="$8" a="?p" ag="g7"/></r>
-<ag xml:id="g76" name="$8" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$8" a="p" ag="g76"><nt n="s" ag="g5"/><nt n="rule" ag="g2"/><nt n="$8" a="?p" ag="g7"/></r>
-<ag xml:id="g77" name="$9" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$9" a="p" ag="g77"><nt n="ppragma" ag="g5"/><nt n="$10" a="?p" ag="g7"/></r>
-<ag xml:id="g78" name="$10" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$10" a="p" ag="g78"><nt n="$11" a="?p" ag="g7"/></r>
-<ag xml:id="g79" name="$11" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$11" a="p" ag="g79"><nt n="s" ag="g5"/><nt n="ppragma" ag="g5"/><nt n="$11" a="?p" ag="g7"/></r>
-<ag xml:id="g80" name="$12" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$12" a="p" ag="g80"><nt n="alt" ag="g2"/><nt n="$13" a="?p" ag="g7"/></r>
-<ag xml:id="g81" name="$13" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$13" a="p" ag="g81"><nt n="$14" a="?p" ag="g7"/></r>
-<ag xml:id="g82" name="$14" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$14" a="p" ag="g82"><t ag="g9"><cs ag="g10" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g5"/><nt n="alt" ag="g2"/><nt n="$14" a="?p" ag="g7"/></r>
-<ag xml:id="g83" name="$15" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$15" a="p" ag="g83"><nt n="dchar" ag="g2"/><nt n="$16" a="p" ag="g4"/></r>
-<ag xml:id="g84" name="$16" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$16" a="p" ag="g84"><nt n="$17" a="?p" ag="g7"/></r>
-<ag xml:id="g85" name="$17" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$17" a="p" ag="g85"><nt n="dchar" ag="g2"/><nt n="$16" a="p" ag="g4"/></r>
-<ag xml:id="g86" name="$18" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$18" a="p" ag="g86"><nt n="schar" ag="g2"/><nt n="$19" a="p" ag="g4"/></r>
-<ag xml:id="g87" name="$19" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$19" a="p" ag="g87"><nt n="$20" a="?p" ag="g7"/></r>
-<ag xml:id="g88" name="$20" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$20" a="p" ag="g88"><nt n="schar" ag="g2"/><nt n="$19" a="p" ag="g4"/></r>
-<ag xml:id="g89" name="$21" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$21" a="p" ag="g89"><t ag="g18"><cs ag="g10" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$22" a="p" ag="g4"/></r>
-<ag xml:id="g90" name="$22" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$22" a="p" ag="g90"><nt n="$23" a="?p" ag="g7"/></r>
-<ag xml:id="g91" name="$23" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$23" a="p" ag="g91"><t ag="g18"><cs ag="g10" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$22" a="p" ag="g4"/></r>
-<ag xml:id="g92" name="$24" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$24" a="p" ag="g92"><nt n="$25" a="?p" ag="g7"/></r>
-<ag xml:id="g93" name="$25" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$25" a="p" ag="g93"><nt n="|$1" ag="g5"/><nt n="$25" a="?p" ag="g7"/></r>
-<ag xml:id="g94" name="$26" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$26" a="p" ag="g94"><nt n="$27" a="?p" ag="g7"/></r>
-<ag xml:id="g95" name="$27" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$27" a="p" ag="g95"><nt n="|$2" ag="g5"/><nt n="$27" a="?p" ag="g7"/></r>
-<ag xml:id="g96" name="$28" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$28" a="p" ag="g96"><nt n="$29" a="?p" ag="g7"/></r>
-<ag xml:id="g97" name="$29" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$29" a="p" ag="g97"><nt n="term" ag="g5"/><nt n="$30" a="p" ag="g4"/></r>
-<ag xml:id="g98" name="$30" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$30" a="p" ag="g98"><nt n="$31" a="?p" ag="g7"/></r>
-<ag xml:id="g99" name="$31" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$31" a="p" ag="g99"><t ag="g9"><c ag="g10" v=","/></t><nt n="s" ag="g5"/><nt n="term" ag="g5"/><nt n="$30" a="p" ag="g4"/></r>
-<ag xml:id="g100" name="$32" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$32" a="p" ag="g100"><nt n="$33" a="?p" ag="g7"/></r>
-<ag xml:id="g101" name="$33" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$33" a="p" ag="g101"><nt n="|$4" ag="g5"/><nt n="$33" a="?p" ag="g7"/></r>
-<ag xml:id="g102" name="$34" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$34" a="p" ag="g102"><nt n="$35" a="?p" ag="g7"/></r>
-<ag xml:id="g103" name="$35" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$35" a="p" ag="g103"><nt n="namefollower" ag="g5"/><nt n="$35" a="?p" ag="g7"/></r>
-<ag xml:id="g104" name="$36" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$36" a="p" ag="g104"><nt n="$37" a="?p" ag="g7"/></r>
-<ag xml:id="g105" name="$37" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$37" a="p" ag="g105"><nt n="member" ag="g5"/><nt n="$38" a="p" ag="g4"/></r>
-<ag xml:id="g106" name="$38" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$38" a="p" ag="g106"><nt n="$39" a="?p" ag="g7"/></r>
-<ag xml:id="g107" name="$39" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$39" a="p" ag="g107"><t ag="g9"><cs ag="g10" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g5"/><nt n="member" ag="g5"/><nt n="$38" a="p" ag="g4"/></r>
-<ag xml:id="g108" name="$40" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$40" a="p" ag="g108"><nt n="$41" a="?p" ag="g7"/></r>
-<ag xml:id="g109" name="$41" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$41" a="p" ag="g109"><nt n="|$5" ag="g5"/><nt n="$41" a="?p" ag="g7"/></r>
-<ag xml:id="g110" name="$42_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$42_option" a="p" ag="g110"><nt n="$9" a="p" ag="g4"/><nt n="s" ag="g5"/></r>
-<ag xml:id="g111" name="$43_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$43_option" a="p" ag="g111"><nt n="|$3" ag="g5"/><nt n="$26" a="?p" ag="g7"/></r>
-<ag xml:id="g112" name="$44_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$44_option" a="p" ag="g112"><nt n="pragma" ag="g2"/><nt n="sp" ag="g5"/></r>
-<ag xml:id="g113" name="$45_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$45_option" a="p" ag="g113"><nt n="pragma" ag="g2"/><nt n="sp" ag="g5"/></r>
-<ag xml:id="g114" name="$46_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$46_option" a="p" ag="g114"><nt n="mark" ag="g20"/><nt n="sp" ag="g5"/></r>
-<ag xml:id="g115" name="$47_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$47_option" a="p" ag="g115"><nt n="pragma" ag="g2"/><nt n="sp" ag="g5"/></r>
-<ag xml:id="g116" name="$48_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$48_option" a="p" ag="g116"><nt n="tmark" ag="g20"/><nt n="sp" ag="g5"/></r>
-<ag xml:id="g117" name="$49_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
-<r n="$49_option" a="p" ag="g117"><nt n="whitespace" ag="g5"/><nt n="pragma-data" ag="g2"/></r>
-<r n="prolog" ag="g6"><nt n="s" ag="g5"/></r>
-<r n="comment" ag="g16"><t ag="g9"><c ag="g10" v="{"/></t><t ag="g9"><c ag="g10" v="}"/></t></r>
-<r n="rule" ag="g19"><nt n="annotation" ag="g5"/><nt n="name" ag="g20"/><nt n="s" ag="g5"/><t ag="g9"><cs ag="g10" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g5"/><nt n="alts" ag="g5"/><t ag="g9"><c ag="g10" v="."/></t></r>
-<r n="repeat0" ag="g26"><nt n="factor" ag="g5"/><t ag="g9"><c ag="g10" v="*"/></t><nt n="s" ag="g5"/></r>
-<r n="repeat1" ag="g28"><nt n="factor" ag="g5"/><t ag="g9"><c ag="g10" v="+"/></t><nt n="s" ag="g5"/></r>
-<r n="annotation" ag="g32"><nt n="$45_option" a="?p" ag="g7"/></r>
-<r n="annotation" ag="g32"><nt n="$46_option" a="?p" ag="g7"/></r>
-<r n="annotation" ag="g32"></r>
-<r n="tannotation" ag="g40"><nt n="$47_option" a="?p" ag="g7"/></r>
-<r n="tannotation" ag="g40"><nt n="$48_option" a="?p" ag="g7"/></r>
-<r n="tannotation" ag="g40"></r>
-<r n="code" ag="g57"><nt n="capital" ag="g5"/></r>
-<r n="pragma" ag="g61"><nt n="pld" ag="g5"/><nt n="pmark" a="?" ag="g62"/><nt n="name" ag="g20"/><nt n="prd" ag="g5"/></r>
-<r n="pragma" ag="g61"><nt n="pld" ag="g5"/><nt n="name" ag="g20"/><nt n="$49_option" a="?p" ag="g7"/><nt n="prd" ag="g5"/></r>
-<r n="pragma" ag="g61"><nt n="pld" ag="g5"/><nt n="name" ag="g20"/><nt n="prd" ag="g5"/></r>
-<r n="$7" a="p" ag="g75"></r>
-<r n="$8" a="p" ag="g76"><nt n="s" ag="g5"/><nt n="rule" ag="g2"/></r>
-<r n="$10" a="p" ag="g78"></r>
-<r n="$11" a="p" ag="g79"><nt n="s" ag="g5"/><nt n="ppragma" ag="g5"/></r>
-<r n="$13" a="p" ag="g81"></r>
-<r n="$14" a="p" ag="g82"><t ag="g9"><cs ag="g10" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g5"/><nt n="alt" ag="g2"/></r>
-<r n="$16" a="p" ag="g84"></r>
-<r n="$19" a="p" ag="g87"></r>
-<r n="$22" a="p" ag="g90"></r>
-<r n="$24" a="p" ag="g92"></r>
-<r n="$25" a="p" ag="g93"><nt n="|$1" ag="g5"/></r>
-<r n="$26" a="p" ag="g94"></r>
-<r n="$27" a="p" ag="g95"><nt n="|$2" ag="g5"/></r>
-<r n="$28" a="p" ag="g96"></r>
-<r n="$30" a="p" ag="g98"></r>
-<r n="$32" a="p" ag="g100"></r>
-<r n="$33" a="p" ag="g101"><nt n="|$4" ag="g5"/></r>
-<r n="$34" a="p" ag="g102"></r>
-<r n="$35" a="p" ag="g103"><nt n="namefollower" ag="g5"/></r>
-<r n="$36" a="p" ag="g104"></r>
-<r n="$38" a="p" ag="g106"></r>
-<r n="$40" a="p" ag="g108"></r>
-<r n="$41" a="p" ag="g109"><nt n="|$5" ag="g5"/></r>
-<check Σ="cf6cdf75e1ad0b95"/>
+<ag xml:id="g4" discard="empty" mark="^"/>
+<ag xml:id="g5" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<ag xml:id="g6" mark="-"/>
+<r n="ixml" ag="g3"><nt n="prolog" ag="g4"/><nt n="$6" a="p" ag="g5"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g7" name="prolog" mark="^"/>
+<ag xml:id="g8" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="prolog" ag="g7"><nt n="s" ag="g6"/><nt n="$42_option" a="?p" ag="g8"/></r>
+<ag xml:id="g9" name="ppragma" mark="-"/>
+<ag xml:id="g10" tmark="-"/>
+<ag xml:id="g11"/>
+<r n="ppragma" ag="g9"><nt n="pragma" ag="g2"/><nt n="s" ag="g6"/><t ag="g10"><c ag="g11" v="."/></t></r>
+<ag xml:id="g12" name="s" mark="-"/>
+<r n="s" ag="g12"><nt n="$24" a="?p" ag="g8"/></r>
+<ag xml:id="g13" name="whitespace" mark="-"/>
+<r n="whitespace" ag="g13"><t ag="g10"><cs ag="g11" inclusion="Zs"/></t></r>
+<r n="whitespace" ag="g13"><nt n="tab" ag="g6"/></r>
+<r n="whitespace" ag="g13"><nt n="lf" ag="g6"/></r>
+<r n="whitespace" ag="g13"><nt n="cr" ag="g6"/></r>
+<ag xml:id="g14" name="tab" mark="-"/>
+<r n="tab" ag="g14"><t ag="g10"><c ag="g11" v="&#x9;"/></t></r>
+<ag xml:id="g15" name="lf" mark="-"/>
+<r n="lf" ag="g15"><t ag="g10"><c ag="g11" v="&#xa;"/></t></r>
+<ag xml:id="g16" name="cr" mark="-"/>
+<r n="cr" ag="g16"><t ag="g10"><c ag="g11" v="&#xd;"/></t></r>
+<ag xml:id="g17" name="comment" mark="^"/>
+<r n="comment" ag="g17"><t ag="g10"><c ag="g11" v="{"/></t><nt n="$43_option" a="?p" ag="g8"/><t ag="g10"><c ag="g11" v="}"/></t></r>
+<ag xml:id="g18" name="cchar" mark="-"/>
+<ag xml:id="g19" tmark="^"/>
+<r n="cchar" ag="g18"><t ag="g19"><cs ag="g11" exclusion="&quot;{}&quot;"/></t></r>
+<ag xml:id="g20" name="rule" mark="^"/>
+<ag xml:id="g21" mark="@"/>
+<r n="rule" ag="g20"><nt n="annotation" ag="g6"/><nt n="name" ag="g21"/><nt n="s" ag="g6"/><t ag="g10"><cs ag="g11" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g6"/><nt n="alts" ag="g6"/><nt n="$44_option" a="?p" ag="g8"/><t ag="g10"><c ag="g11" v="."/></t></r>
+<ag xml:id="g22" name="mark" mark="@"/>
+<r n="mark" ag="g22"><t ag="g19"><cs ag="g11" inclusion="&quot;@-^&quot;"/></t></r>
+<ag xml:id="g23" name="alts" mark="^"/>
+<r n="alts" ag="g23"><nt n="$12" a="p" ag="g5"/></r>
+<ag xml:id="g24" name="alt" mark="^"/>
+<r n="alt" ag="g24"><nt n="$28" a="p" ag="g5"/></r>
+<ag xml:id="g25" name="term" mark="-"/>
+<r n="term" ag="g25"><nt n="factor" ag="g6"/></r>
+<r n="term" ag="g25"><nt n="option" ag="g2"/></r>
+<r n="term" ag="g25"><nt n="repeat0" ag="g2"/></r>
+<r n="term" ag="g25"><nt n="repeat1" ag="g2"/></r>
+<ag xml:id="g26" name="factor" mark="-"/>
+<r n="factor" ag="g26"><nt n="terminal" ag="g6"/></r>
+<r n="factor" ag="g26"><nt n="nonterminal" ag="g2"/></r>
+<r n="factor" ag="g26"><t ag="g10"><c ag="g11" v="("/></t><nt n="s" ag="g6"/><nt n="alts" ag="g2"/><t ag="g10"><c ag="g11" v=")"/></t><nt n="s" ag="g6"/></r>
+<ag xml:id="g27" name="repeat0" mark="^"/>
+<ag xml:id="g28" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="^"/>
+<r n="repeat0" ag="g27"><nt n="factor" ag="g6"/><t ag="g10"><c ag="g11" v="*"/></t><nt n="s" ag="g6"/><nt n="sep" a="?" ag="g28"/></r>
+<ag xml:id="g29" name="repeat1" mark="^"/>
+<r n="repeat1" ag="g29"><nt n="factor" ag="g6"/><t ag="g10"><c ag="g11" v="+"/></t><nt n="s" ag="g6"/><nt n="sep" a="?" ag="g28"/></r>
+<ag xml:id="g30" name="option" mark="^"/>
+<r n="option" ag="g30"><nt n="factor" ag="g6"/><t ag="g10"><c ag="g11" v="?"/></t><nt n="s" ag="g6"/></r>
+<ag xml:id="g31" name="sep" mark="^"/>
+<r n="sep" ag="g31"><nt n="factor" ag="g6"/></r>
+<ag xml:id="g32" name="nonterminal" mark="^"/>
+<r n="nonterminal" ag="g32"><nt n="annotation" ag="g6"/><nt n="name" ag="g21"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g33" name="annotation" mark="-"/>
+<r n="annotation" ag="g33"><nt n="$45_option" a="?p" ag="g8"/><nt n="$46_option" a="?p" ag="g8"/></r>
+<ag xml:id="g34" name="sp" mark="-"/>
+<r n="sp" ag="g34"><nt n="$32" a="?p" ag="g8"/></r>
+<ag xml:id="g35" name="terminal" mark="-"/>
+<r n="terminal" ag="g35"><nt n="literal" ag="g2"/></r>
+<r n="terminal" ag="g35"><nt n="charset" ag="g6"/></r>
+<ag xml:id="g36" name="literal" mark="^"/>
+<r n="literal" ag="g36"><nt n="quoted" ag="g6"/></r>
+<r n="literal" ag="g36"><nt n="encoded" ag="g6"/></r>
+<ag xml:id="g37" name="quoted" mark="-"/>
+<r n="quoted" ag="g37"><nt n="tannotation" ag="g6"/><nt n="string" ag="g21"/></r>
+<ag xml:id="g38" name="name" mark="@"/>
+<r n="name" ag="g38"><nt n="namestart" ag="g6"/><nt n="$34" a="?p" ag="g8"/></r>
+<ag xml:id="g39" name="namestart" mark="-"/>
+<r n="namestart" ag="g39"><t ag="g19"><cs ag="g11" inclusion="&quot;_&quot;;L"/></t></r>
+<ag xml:id="g40" name="namefollower" mark="-"/>
+<r n="namefollower" ag="g40"><nt n="namestart" ag="g6"/></r>
+<r n="namefollower" ag="g40"><t ag="g19"><cs ag="g11" inclusion="&quot;⁀·-.‿&quot;;Nd;Mn"/></t></r>
+<ag xml:id="g41" name="tannotation" mark="-"/>
+<r n="tannotation" ag="g41"><nt n="$47_option" a="?p" ag="g8"/><nt n="$48_option" a="?p" ag="g8"/></r>
+<ag xml:id="g42" name="tmark" mark="@"/>
+<r n="tmark" ag="g42"><t ag="g19"><cs ag="g11" inclusion="&quot;-^&quot;"/></t></r>
+<ag xml:id="g43" name="string" mark="@"/>
+<r n="string" ag="g43"><t ag="g10"><c ag="g11" v="&quot;"/></t><nt n="$15" a="p" ag="g5"/><t ag="g10"><c ag="g11" v="&quot;"/></t><nt n="s" ag="g6"/></r>
+<r n="string" ag="g43"><t ag="g10"><c ag="g11" v="'"/></t><nt n="$18" a="p" ag="g5"/><t ag="g10"><c ag="g11" v="'"/></t><nt n="s" ag="g6"/></r>
+<ag xml:id="g44" name="dchar" mark="^"/>
+<r n="dchar" ag="g44"><t ag="g19"><cs ag="g11" exclusion="&quot;&amp;quot;&quot;;'&#xa;';'&#xd;'"/></t></r>
+<r n="dchar" ag="g44"><t ag="g19"><c ag="g11" v="&quot;"/></t><t ag="g10"><c ag="g11" v="&quot;"/></t></r>
+<ag xml:id="g45" name="schar" mark="^"/>
+<r n="schar" ag="g45"><t ag="g19"><cs ag="g11" exclusion="&quot;'&quot;;'&#xa;';'&#xd;'"/></t></r>
+<r n="schar" ag="g45"><t ag="g19"><c ag="g11" v="'"/></t><t ag="g10"><c ag="g11" v="'"/></t></r>
+<ag xml:id="g46" name="encoded" mark="-"/>
+<r n="encoded" ag="g46"><nt n="tannotation" ag="g6"/><t ag="g10"><c ag="g11" v="#"/></t><nt n="hex" ag="g21"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g47" name="hex" mark="^"/>
+<r n="hex" ag="g47"><nt n="$21" a="p" ag="g5"/></r>
+<ag xml:id="g48" name="charset" mark="-"/>
+<r n="charset" ag="g48"><nt n="inclusion" ag="g2"/></r>
+<r n="charset" ag="g48"><nt n="exclusion" ag="g2"/></r>
+<ag xml:id="g49" name="inclusion" mark="^"/>
+<r n="inclusion" ag="g49"><nt n="tannotation" ag="g6"/><nt n="set" ag="g6"/></r>
+<ag xml:id="g50" name="exclusion" mark="^"/>
+<r n="exclusion" ag="g50"><nt n="tannotation" ag="g6"/><t ag="g10"><c ag="g11" v="~"/></t><nt n="s" ag="g6"/><nt n="set" ag="g6"/></r>
+<ag xml:id="g51" name="set" mark="-"/>
+<r n="set" ag="g51"><t ag="g10"><c ag="g11" v="["/></t><nt n="s" ag="g6"/><nt n="$36" a="p" ag="g5"/><t ag="g10"><c ag="g11" v="]"/></t><nt n="s" ag="g6"/></r>
+<ag xml:id="g52" name="member" mark="-"/>
+<r n="member" ag="g52"><nt n="literal" ag="g2"/></r>
+<r n="member" ag="g52"><nt n="range" ag="g2"/></r>
+<r n="member" ag="g52"><nt n="class" ag="g2"/></r>
+<ag xml:id="g53" name="range" mark="^"/>
+<r n="range" ag="g53"><nt n="from" ag="g21"/><nt n="s" ag="g6"/><t ag="g10"><c ag="g11" v="-"/></t><nt n="s" ag="g6"/><nt n="to" ag="g21"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g54" name="from" mark="@"/>
+<r n="from" ag="g54"><nt n="character" ag="g6"/></r>
+<ag xml:id="g55" name="to" mark="@"/>
+<r n="to" ag="g55"><nt n="character" ag="g6"/></r>
+<ag xml:id="g56" name="character" mark="-"/>
+<r n="character" ag="g56"><t ag="g10"><c ag="g11" v="&quot;"/></t><nt n="dchar" ag="g2"/><t ag="g10"><c ag="g11" v="&quot;"/></t></r>
+<r n="character" ag="g56"><t ag="g10"><c ag="g11" v="'"/></t><nt n="schar" ag="g2"/><t ag="g10"><c ag="g11" v="'"/></t></r>
+<r n="character" ag="g56"><t ag="g19"><c ag="g11" v="#"/></t><nt n="hex" ag="g2"/></r>
+<ag xml:id="g57" name="class" mark="^"/>
+<r n="class" ag="g57"><nt n="code" ag="g21"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g58" name="code" mark="@"/>
+<ag xml:id="g59" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="-"/>
+<r n="code" ag="g58"><nt n="capital" ag="g6"/><nt n="letter" a="?" ag="g59"/></r>
+<ag xml:id="g60" name="capital" mark="-"/>
+<r n="capital" ag="g60"><t ag="g19"><cs ag="g11" inclusion="'A'-'Z'"/></t></r>
+<ag xml:id="g61" name="letter" mark="-"/>
+<r n="letter" ag="g61"><t ag="g19"><cs ag="g11" inclusion="'a'-'z'"/></t></r>
+<ag xml:id="g62" name="pragma" mark="^"/>
+<ag xml:id="g63" httpsǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.CoffeeGrinderǝ2f.attributesǝ2f.optionality="optional" mark="@"/>
+<r n="pragma" ag="g62"><nt n="pld" ag="g6"/><nt n="pmark" a="?" ag="g63"/><nt n="name" ag="g21"/><nt n="$49_option" a="?p" ag="g8"/><nt n="prd" ag="g6"/></r>
+<ag xml:id="g64" name="pmark" mark="@"/>
+<r n="pmark" ag="g64"><t ag="g19"><cs ag="g11" inclusion="&quot;@^?&quot;"/></t></r>
+<ag xml:id="g65" name="pragma-data" mark="^"/>
+<r n="pragma-data" ag="g65"><nt n="$40" a="?p" ag="g8"/></r>
+<ag xml:id="g66" name="pragma-char" mark="-"/>
+<r n="pragma-char" ag="g66"><t ag="g19"><cs ag="g11" exclusion="&quot;{}&quot;"/></t></r>
+<ag xml:id="g67" name="bracket-pair" mark="-"/>
+<r n="bracket-pair" ag="g67"><t ag="g19"><c ag="g11" v="{"/></t><nt n="pragma-data" ag="g6"/><t ag="g19"><c ag="g11" v="}"/></t></r>
+<ag xml:id="g68" name="pld" mark="-"/>
+<r n="pld" ag="g68"><t ag="g10"><c ag="g11" v="{"/></t><t ag="g10"><c ag="g11" v="["/></t></r>
+<ag xml:id="g69" name="prd" mark="-"/>
+<r n="prd" ag="g69"><t ag="g10"><c ag="g11" v="]"/></t><t ag="g10"><c ag="g11" v="}"/></t></r>
+<ag xml:id="g70" name="|$1" mark="-"/>
+<r n="|$1" ag="g70"><nt n="whitespace" ag="g6"/></r>
+<r n="|$1" ag="g70"><nt n="comment" ag="g2"/></r>
+<ag xml:id="g71" name="|$2" mark="-"/>
+<r n="|$2" ag="g71"><nt n="cchar" ag="g6"/></r>
+<r n="|$2" ag="g71"><nt n="comment" ag="g2"/></r>
+<ag xml:id="g72" name="|$3" mark="-"/>
+<r n="|$3" ag="g72"><nt n="comment" ag="g2"/></r>
+<r n="|$3" ag="g72"><t ag="g19"><cs ag="g11" exclusion="'[';']';&quot;{}&quot;"/></t></r>
+<ag xml:id="g73" name="|$4" mark="-"/>
+<r n="|$4" ag="g73"><nt n="whitespace" ag="g6"/></r>
+<r n="|$4" ag="g73"><nt n="comment" ag="g2"/></r>
+<r n="|$4" ag="g73"><nt n="pragma" ag="g2"/></r>
+<ag xml:id="g74" name="|$5" mark="-"/>
+<r n="|$5" ag="g74"><nt n="pragma-char" ag="g6"/></r>
+<r n="|$5" ag="g74"><nt n="bracket-pair" ag="g6"/></r>
+<ag xml:id="g75" name="$6" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$6" a="p" ag="g75"><nt n="rule" ag="g2"/><nt n="$7" a="?p" ag="g8"/></r>
+<ag xml:id="g76" name="$7" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$7" a="p" ag="g76"><nt n="$8" a="?p" ag="g8"/></r>
+<ag xml:id="g77" name="$8" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$8" a="p" ag="g77"><nt n="s" ag="g6"/><nt n="rule" ag="g2"/><nt n="$8" a="?p" ag="g8"/></r>
+<ag xml:id="g78" name="$9" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$9" a="p" ag="g78"><nt n="ppragma" ag="g6"/><nt n="$10" a="?p" ag="g8"/></r>
+<ag xml:id="g79" name="$10" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$10" a="p" ag="g79"><nt n="$11" a="?p" ag="g8"/></r>
+<ag xml:id="g80" name="$11" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$11" a="p" ag="g80"><nt n="s" ag="g6"/><nt n="ppragma" ag="g6"/><nt n="$11" a="?p" ag="g8"/></r>
+<ag xml:id="g81" name="$12" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$12" a="p" ag="g81"><nt n="alt" ag="g2"/><nt n="$13" a="?p" ag="g8"/></r>
+<ag xml:id="g82" name="$13" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$13" a="p" ag="g82"><nt n="$14" a="?p" ag="g8"/></r>
+<ag xml:id="g83" name="$14" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$14" a="p" ag="g83"><t ag="g10"><cs ag="g11" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g6"/><nt n="alt" ag="g2"/><nt n="$14" a="?p" ag="g8"/></r>
+<ag xml:id="g84" name="$15" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$15" a="p" ag="g84"><nt n="dchar" ag="g2"/><nt n="$16" a="p" ag="g5"/></r>
+<ag xml:id="g85" name="$16" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$16" a="p" ag="g85"><nt n="$17" a="?p" ag="g8"/></r>
+<ag xml:id="g86" name="$17" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$17" a="p" ag="g86"><nt n="dchar" ag="g2"/><nt n="$16" a="p" ag="g5"/></r>
+<ag xml:id="g87" name="$18" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$18" a="p" ag="g87"><nt n="schar" ag="g2"/><nt n="$19" a="p" ag="g5"/></r>
+<ag xml:id="g88" name="$19" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$19" a="p" ag="g88"><nt n="$20" a="?p" ag="g8"/></r>
+<ag xml:id="g89" name="$20" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$20" a="p" ag="g89"><nt n="schar" ag="g2"/><nt n="$19" a="p" ag="g5"/></r>
+<ag xml:id="g90" name="$21" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$21" a="p" ag="g90"><t ag="g19"><cs ag="g11" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$22" a="p" ag="g5"/></r>
+<ag xml:id="g91" name="$22" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$22" a="p" ag="g91"><nt n="$23" a="?p" ag="g8"/></r>
+<ag xml:id="g92" name="$23" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$23" a="p" ag="g92"><t ag="g19"><cs ag="g11" inclusion="'0'-'9';'a'-'f';'A'-'F'"/></t><nt n="$22" a="p" ag="g5"/></r>
+<ag xml:id="g93" name="$24" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$24" a="p" ag="g93"><nt n="$25" a="?p" ag="g8"/></r>
+<ag xml:id="g94" name="$25" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$25" a="p" ag="g94"><nt n="|$1" ag="g6"/><nt n="$25" a="?p" ag="g8"/></r>
+<ag xml:id="g95" name="$26" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$26" a="p" ag="g95"><nt n="$27" a="?p" ag="g8"/></r>
+<ag xml:id="g96" name="$27" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$27" a="p" ag="g96"><nt n="|$2" ag="g6"/><nt n="$27" a="?p" ag="g8"/></r>
+<ag xml:id="g97" name="$28" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$28" a="p" ag="g97"><nt n="$29" a="?p" ag="g8"/></r>
+<ag xml:id="g98" name="$29" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$29" a="p" ag="g98"><nt n="term" ag="g6"/><nt n="$30" a="p" ag="g5"/></r>
+<ag xml:id="g99" name="$30" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$30" a="p" ag="g99"><nt n="$31" a="?p" ag="g8"/></r>
+<ag xml:id="g100" name="$31" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$31" a="p" ag="g100"><t ag="g10"><c ag="g11" v=","/></t><nt n="s" ag="g6"/><nt n="term" ag="g6"/><nt n="$30" a="p" ag="g5"/></r>
+<ag xml:id="g101" name="$32" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$32" a="p" ag="g101"><nt n="$33" a="?p" ag="g8"/></r>
+<ag xml:id="g102" name="$33" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$33" a="p" ag="g102"><nt n="|$4" ag="g6"/><nt n="$33" a="?p" ag="g8"/></r>
+<ag xml:id="g103" name="$34" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$34" a="p" ag="g103"><nt n="$35" a="?p" ag="g8"/></r>
+<ag xml:id="g104" name="$35" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$35" a="p" ag="g104"><nt n="namefollower" ag="g6"/><nt n="$35" a="?p" ag="g8"/></r>
+<ag xml:id="g105" name="$36" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$36" a="p" ag="g105"><nt n="$37" a="?p" ag="g8"/></r>
+<ag xml:id="g106" name="$37" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$37" a="p" ag="g106"><nt n="member" ag="g6"/><nt n="$38" a="p" ag="g5"/></r>
+<ag xml:id="g107" name="$38" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$38" a="p" ag="g107"><nt n="$39" a="?p" ag="g8"/></r>
+<ag xml:id="g108" name="$39" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$39" a="p" ag="g108"><t ag="g10"><cs ag="g11" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g6"/><nt n="member" ag="g6"/><nt n="$38" a="p" ag="g5"/></r>
+<ag xml:id="g109" name="$40" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$40" a="p" ag="g109"><nt n="$41" a="?p" ag="g8"/></r>
+<ag xml:id="g110" name="$41" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$41" a="p" ag="g110"><nt n="|$5" ag="g6"/><nt n="$41" a="?p" ag="g8"/></r>
+<ag xml:id="g111" name="$42_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$42_option" a="p" ag="g111"><nt n="$9" a="p" ag="g5"/><nt n="s" ag="g6"/></r>
+<ag xml:id="g112" name="$43_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$43_option" a="p" ag="g112"><nt n="|$3" ag="g6"/><nt n="$26" a="?p" ag="g8"/></r>
+<ag xml:id="g113" name="$44_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$44_option" a="p" ag="g113"><nt n="pragma" ag="g2"/><nt n="sp" ag="g6"/></r>
+<ag xml:id="g114" name="$45_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$45_option" a="p" ag="g114"><nt n="pragma" ag="g2"/><nt n="sp" ag="g6"/></r>
+<ag xml:id="g115" name="$46_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$46_option" a="p" ag="g115"><nt n="mark" ag="g21"/><nt n="sp" ag="g6"/></r>
+<ag xml:id="g116" name="$47_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$47_option" a="p" ag="g116"><nt n="pragma" ag="g2"/><nt n="sp" ag="g6"/></r>
+<ag xml:id="g117" name="$48_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$48_option" a="p" ag="g117"><nt n="tmark" ag="g21"/><nt n="sp" ag="g6"/></r>
+<ag xml:id="g118" name="$49_option" httpǝ3a.ǝ2f.ǝ2f.ninemlǝ2e.orgǝ2f.coffeegrinderǝ2f.attributesǝ2f.prune="allowed" mark="-"/>
+<r n="$49_option" a="p" ag="g118"><nt n="whitespace" ag="g6"/><nt n="pragma-data" ag="g2"/></r>
+<r n="prolog" ag="g7"><nt n="s" ag="g6"/></r>
+<r n="comment" ag="g17"><t ag="g10"><c ag="g11" v="{"/></t><t ag="g10"><c ag="g11" v="}"/></t></r>
+<r n="rule" ag="g20"><nt n="annotation" ag="g6"/><nt n="name" ag="g21"/><nt n="s" ag="g6"/><t ag="g10"><cs ag="g11" inclusion="&quot;:=&quot;"/></t><nt n="s" ag="g6"/><nt n="alts" ag="g6"/><t ag="g10"><c ag="g11" v="."/></t></r>
+<r n="repeat0" ag="g27"><nt n="factor" ag="g6"/><t ag="g10"><c ag="g11" v="*"/></t><nt n="s" ag="g6"/></r>
+<r n="repeat1" ag="g29"><nt n="factor" ag="g6"/><t ag="g10"><c ag="g11" v="+"/></t><nt n="s" ag="g6"/></r>
+<r n="annotation" ag="g33"><nt n="$45_option" a="?p" ag="g8"/></r>
+<r n="annotation" ag="g33"><nt n="$46_option" a="?p" ag="g8"/></r>
+<r n="annotation" ag="g33"></r>
+<r n="tannotation" ag="g41"><nt n="$47_option" a="?p" ag="g8"/></r>
+<r n="tannotation" ag="g41"><nt n="$48_option" a="?p" ag="g8"/></r>
+<r n="tannotation" ag="g41"></r>
+<r n="code" ag="g58"><nt n="capital" ag="g6"/></r>
+<r n="pragma" ag="g62"><nt n="pld" ag="g6"/><nt n="pmark" a="?" ag="g63"/><nt n="name" ag="g21"/><nt n="prd" ag="g6"/></r>
+<r n="pragma" ag="g62"><nt n="pld" ag="g6"/><nt n="name" ag="g21"/><nt n="$49_option" a="?p" ag="g8"/><nt n="prd" ag="g6"/></r>
+<r n="pragma" ag="g62"><nt n="pld" ag="g6"/><nt n="name" ag="g21"/><nt n="prd" ag="g6"/></r>
+<r n="$7" a="p" ag="g76"></r>
+<r n="$8" a="p" ag="g77"><nt n="s" ag="g6"/><nt n="rule" ag="g2"/></r>
+<r n="$10" a="p" ag="g79"></r>
+<r n="$11" a="p" ag="g80"><nt n="s" ag="g6"/><nt n="ppragma" ag="g6"/></r>
+<r n="$13" a="p" ag="g82"></r>
+<r n="$14" a="p" ag="g83"><t ag="g10"><cs ag="g11" inclusion="&quot;;|&quot;"/></t><nt n="s" ag="g6"/><nt n="alt" ag="g2"/></r>
+<r n="$16" a="p" ag="g85"></r>
+<r n="$19" a="p" ag="g88"></r>
+<r n="$22" a="p" ag="g91"></r>
+<r n="$24" a="p" ag="g93"></r>
+<r n="$25" a="p" ag="g94"><nt n="|$1" ag="g6"/></r>
+<r n="$26" a="p" ag="g95"></r>
+<r n="$27" a="p" ag="g96"><nt n="|$2" ag="g6"/></r>
+<r n="$28" a="p" ag="g97"></r>
+<r n="$30" a="p" ag="g99"></r>
+<r n="$32" a="p" ag="g101"></r>
+<r n="$33" a="p" ag="g102"><nt n="|$4" ag="g6"/></r>
+<r n="$34" a="p" ag="g103"></r>
+<r n="$35" a="p" ag="g104"><nt n="namefollower" ag="g6"/></r>
+<r n="$36" a="p" ag="g105"></r>
+<r n="$38" a="p" ag="g107"></r>
+<r n="$40" a="p" ag="g109"></r>
+<r n="$41" a="p" ag="g110"><nt n="|$5" ag="g6"/></r>
+<check Σ="c1fa740dc42739de"/>
 </grammar>
 

--- a/src/main/resources/org/nineml/coffeefilter/pragmas.ixml
+++ b/src/main/resources/org/nineml/coffeefilter/pragmas.ixml
@@ -1,95 +1,98 @@
+ixml: {[nineml discard empty]} prolog, rule+s, s. 
+
 { ixml with pragmas, hacked by ndw to remove qnames }
+{ this comment is after the first rule so that the  }
+{ prolog will be empty (and discarded).             }
 
-         ixml: prolog, rule+s, s. 
-       prolog: s, (ppragma+s, s)?. 
-     -ppragma: pragma, s, -'.'.
+prolog: s, (ppragma+s, s)?. 
+-ppragma: pragma, s, -'.'.
 
-           -s: (whitespace; comment)*.
-  -whitespace: -[Zs]; tab; lf; cr.
-         -tab: -#9.
-          -lf: -#a.
-          -cr: -#d.
-      comment: -"{", ((comment; ~[#5B; #5D; "{}"]), (cchar; comment)*)?, -"}".
-       -cchar: ~["{}"].
+-s: (whitespace; comment)*.
+-whitespace: -[Zs]; tab; lf; cr.
+-tab: -#9.
+-lf: -#a.
+-cr: -#d.
+comment: -"{", ((comment; ~[#5B; #5D; "{}"]), (cchar; comment)*)?, -"}".
+-cchar: ~["{}"].
 
-         rule: annotation, name, s, -["=:"], s, -alts, (pragma, sp)?, -".". 
+rule: annotation, name, s, -["=:"], s, -alts, (pragma, sp)?, -".". 
 
-        @mark: ["@^-"].
-         alts: alt+(-[";|"], s).
-          alt: term*(-",", s).
-        -term: factor;
-               option;
-               repeat0;
-               repeat1.
-      -factor: terminal;
-               nonterminal;
-               -"(", s, alts, -")", s.
-      repeat0: factor, -"*", s, sep?.
-      repeat1: factor, -"+", s, sep?.
-       option: factor, -"?", s.
-          sep: factor.
+@mark: ["@^-"].
+alts: alt+(-[";|"], s).
+alt: term*(-",", s).
+-term: factor;
+option;
+repeat0;
+repeat1.
+-factor: terminal;
+nonterminal;
+-"(", s, alts, -")", s.
+repeat0: factor, -"*", s, sep?.
+repeat1: factor, -"+", s, sep?.
+option: factor, -"?", s.
+sep: factor.
 
-  nonterminal: annotation, name, s.
-  -annotation: (pragma, sp)?, (mark, sp)?.
-          -sp: (whitespace; comment; pragma)*.
+nonterminal: annotation, name, s.
+-annotation: (pragma, sp)?, (mark, sp)?.
+-sp: (whitespace; comment; pragma)*.
 
-    -terminal: literal; 
-               charset.
-      literal: quoted;
-               encoded.
-      -quoted: tannotation, string.
+-terminal: literal; 
+charset.
+literal: quoted;
+encoded.
+-quoted: tannotation, string.
 
-        @name: namestart, namefollower*.
-   -namestart: ["_"; L].
+@name: namestart, namefollower*.
+-namestart: ["_"; L].
 -namefollower: namestart; ["-.·‿⁀"; Nd; Mn].
 
- -tannotation: (pragma, sp)?, (tmark, sp)?.
+-tannotation: (pragma, sp)?, (tmark, sp)?.
 
-       @tmark: ["^-"].
-      @string: -'"', dchar+, -'"', s;
-               -"'", schar+, -"'", s.
-        dchar: ~['"'; #a; #d];
-               '"', -'"'. {all characters except line breaks; quotes must be doubled}
-        schar: ~["'"; #a; #d];
-               "'", -"'". {all characters except line breaks; quotes must be doubled}
+@tmark: ["^-"].
+@string: -'"', dchar+, -'"', s;
+-"'", schar+, -"'", s.
+dchar: ~['"'; #a; #d];
+'"', -'"'. {all characters except line breaks; quotes must be doubled}
+schar: ~["'"; #a; #d];
+"'", -"'". {all characters except line breaks; quotes must be doubled}
 
-     -encoded: tannotation, -"#", @hex, s.
+-encoded: tannotation, -"#", @hex, s.
 
-          hex: ["0"-"9"; "a"-"f"; "A"-"F"]+.
+hex: ["0"-"9"; "a"-"f"; "A"-"F"]+.
 
-     -charset: inclusion; 
-               exclusion.
-    inclusion: tannotation,          set.
-    exclusion: tannotation, -"~", s, set.
-         -set: -"[", s,  member*(-[";|"], s), -"]", s.
-      -member: literal;
-               range;
-               class.
-        range: from, s, -"-", s, to, s.
-        @from: character.
-          @to: character.
-   -character: -'"', dchar, -'"';
-               -"'", schar, -"'";
-               "#", hex.
-        class: code, s.
-        @code: capital, letter?.
-     -capital: ["A"-"Z"].
-      -letter: ["a"-"z"].
+-charset: inclusion; 
+exclusion.
+inclusion: tannotation,          set.
+exclusion: tannotation, -"~", s, set.
+-set: -"[", s,  member*(-[";|"], s), -"]", s.
+-member: literal;
+range;
+class.
+range: from, s, -"-", s, to, s.
+@from: character.
+@to: character.
+-character: -'"', dchar, -'"';
+-"'", schar, -"'";
+"#", hex.
+class: code, s.
+@code: capital, letter?.
+-capital: ["A"-"Z"].
+-letter: ["a"-"z"].
 
-       pragma: pld, @pmark?, @name, (whitespace, pragma-data)?, prd. 
+pragma: pld, @pmark?, @name, (whitespace, pragma-data)?, prd. 
 {
-       @pname: -QName; -UQName. 
+@pname: -QName; -UQName. 
 }
-       @pmark: ["@^?"].
-  pragma-data: (-pragma-char; -bracket-pair)*.
- -pragma-char: ~["{}"].
+@pmark: ["@^?"].
+pragma-data: (-pragma-char; -bracket-pair)*.
+-pragma-char: ~["{}"].
 -bracket-pair: '{', -pragma-data, '}'.
 
 {
-       -QName: -name, ':', -name.
-      -UQName: 'Q{', -ns-name, '}', -name.
-     -ns-name: ~["{}"; '"'; "'"]* .
+-QName: -name, ':', -name.
+-UQName: 'Q{', -ns-name, '}', -name.
+-ns-name: ~["{}"; '"'; "'"]* .
 }
 
-         -pld: -"{[".
-         -prd: -"]}".
+-pld: -"{[".
+-prd: -"]}".

--- a/src/main/resources/org/nineml/coffeefilter/pragmas.xml
+++ b/src/main/resources/org/nineml/coffeefilter/pragmas.xml
@@ -1,0 +1,631 @@
+<ixml>
+   <prolog/>
+   <rule name="ixml">
+      <alt>
+         <nonterminal name="prolog">
+            <pragma name="nineml">
+               <pragma-data>discard empty</pragma-data>
+            </pragma>
+         </nonterminal>
+         <repeat1>
+            <nonterminal name="rule"/>
+            <sep>
+               <nonterminal name="s"/>
+            </sep>
+         </repeat1>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <comment> ixml with pragmas, hacked by ndw to remove qnames </comment>
+   <comment> this comment is after the first rule so that the  </comment>
+   <comment> prolog will be empty (and discarded).             </comment>
+   <rule name="prolog">
+      <alt>
+         <nonterminal name="s"/>
+         <option>
+            <alts>
+               <alt>
+                  <repeat1>
+                     <nonterminal name="ppragma"/>
+                     <sep>
+                        <nonterminal name="s"/>
+                     </sep>
+                  </repeat1>
+                  <nonterminal name="s"/>
+               </alt>
+            </alts>
+         </option>
+      </alt>
+   </rule>
+   <rule mark="-" name="ppragma">
+      <alt>
+         <nonterminal name="pragma"/>
+         <nonterminal name="s"/>
+         <literal tmark="-" string="."/>
+      </alt>
+   </rule>
+   <rule mark="-" name="s">
+      <alt>
+         <repeat0>
+            <alts>
+               <alt>
+                  <nonterminal name="whitespace"/>
+               </alt>
+               <alt>
+                  <nonterminal name="comment"/>
+               </alt>
+            </alts>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark="-" name="whitespace">
+      <alt>
+         <inclusion tmark="-">
+            <class code="Zs"/>
+         </inclusion>
+      </alt>
+      <alt>
+         <nonterminal name="tab"/>
+      </alt>
+      <alt>
+         <nonterminal name="lf"/>
+      </alt>
+      <alt>
+         <nonterminal name="cr"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="tab">
+      <alt>
+         <literal tmark="-" hex="9"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="lf">
+      <alt>
+         <literal tmark="-" hex="a"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="cr">
+      <alt>
+         <literal tmark="-" hex="d"/>
+      </alt>
+   </rule>
+   <rule name="comment">
+      <alt>
+         <literal tmark="-" string="{"/>
+         <option>
+            <alts>
+               <alt>
+                  <alts>
+                     <alt>
+                        <nonterminal name="comment"/>
+                     </alt>
+                     <alt>
+                        <exclusion>
+                           <literal hex="5B"/>
+                           <literal hex="5D"/>
+                           <literal string="{}"/>
+                        </exclusion>
+                     </alt>
+                  </alts>
+                  <repeat0>
+                     <alts>
+                        <alt>
+                           <nonterminal name="cchar"/>
+                        </alt>
+                        <alt>
+                           <nonterminal name="comment"/>
+                        </alt>
+                     </alts>
+                  </repeat0>
+               </alt>
+            </alts>
+         </option>
+         <literal tmark="-" string="}"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="cchar">
+      <alt>
+         <exclusion>
+            <literal string="{}"/>
+         </exclusion>
+      </alt>
+   </rule>
+   <rule name="rule">
+      <alt>
+         <nonterminal name="annotation"/>
+         <nonterminal name="name"/>
+         <nonterminal name="s"/>
+         <inclusion tmark="-">
+            <literal string="=:"/>
+         </inclusion>
+         <nonterminal name="s"/>
+         <nonterminal mark="-" name="alts"/>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="pragma"/>
+                  <nonterminal name="sp"/>
+               </alt>
+            </alts>
+         </option>
+         <literal tmark="-" string="."/>
+      </alt>
+   </rule>
+   <rule mark="@" name="mark">
+      <alt>
+         <inclusion>
+            <literal string="@^-"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule name="alts">
+      <alt>
+         <repeat1>
+            <nonterminal name="alt"/>
+            <sep>
+               <alts>
+                  <alt>
+                     <inclusion tmark="-">
+                        <literal string=";|"/>
+                     </inclusion>
+                     <nonterminal name="s"/>
+                  </alt>
+               </alts>
+            </sep>
+         </repeat1>
+      </alt>
+   </rule>
+   <rule name="alt">
+      <alt>
+         <repeat0>
+            <nonterminal name="term"/>
+            <sep>
+               <alts>
+                  <alt>
+                     <literal tmark="-" string=","/>
+                     <nonterminal name="s"/>
+                  </alt>
+               </alts>
+            </sep>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark="-" name="term">
+      <alt>
+         <nonterminal name="factor"/>
+      </alt>
+      <alt>
+         <nonterminal name="option"/>
+      </alt>
+      <alt>
+         <nonterminal name="repeat0"/>
+      </alt>
+      <alt>
+         <nonterminal name="repeat1"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="factor">
+      <alt>
+         <nonterminal name="terminal"/>
+      </alt>
+      <alt>
+         <nonterminal name="nonterminal"/>
+      </alt>
+      <alt>
+         <literal tmark="-" string="("/>
+         <nonterminal name="s"/>
+         <nonterminal name="alts"/>
+         <literal tmark="-" string=")"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule name="repeat0">
+      <alt>
+         <nonterminal name="factor"/>
+         <literal tmark="-" string="*"/>
+         <nonterminal name="s"/>
+         <option>
+            <nonterminal name="sep"/>
+         </option>
+      </alt>
+   </rule>
+   <rule name="repeat1">
+      <alt>
+         <nonterminal name="factor"/>
+         <literal tmark="-" string="+"/>
+         <nonterminal name="s"/>
+         <option>
+            <nonterminal name="sep"/>
+         </option>
+      </alt>
+   </rule>
+   <rule name="option">
+      <alt>
+         <nonterminal name="factor"/>
+         <literal tmark="-" string="?"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule name="sep">
+      <alt>
+         <nonterminal name="factor"/>
+      </alt>
+   </rule>
+   <rule name="nonterminal">
+      <alt>
+         <nonterminal name="annotation"/>
+         <nonterminal name="name"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="annotation">
+      <alt>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="pragma"/>
+                  <nonterminal name="sp"/>
+               </alt>
+            </alts>
+         </option>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="mark"/>
+                  <nonterminal name="sp"/>
+               </alt>
+            </alts>
+         </option>
+      </alt>
+   </rule>
+   <rule mark="-" name="sp">
+      <alt>
+         <repeat0>
+            <alts>
+               <alt>
+                  <nonterminal name="whitespace"/>
+               </alt>
+               <alt>
+                  <nonterminal name="comment"/>
+               </alt>
+               <alt>
+                  <nonterminal name="pragma"/>
+               </alt>
+            </alts>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark="-" name="terminal">
+      <alt>
+         <nonterminal name="literal"/>
+      </alt>
+      <alt>
+         <nonterminal name="charset"/>
+      </alt>
+   </rule>
+   <rule name="literal">
+      <alt>
+         <nonterminal name="quoted"/>
+      </alt>
+      <alt>
+         <nonterminal name="encoded"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="quoted">
+      <alt>
+         <nonterminal name="tannotation"/>
+         <nonterminal name="string"/>
+      </alt>
+   </rule>
+   <rule mark="@" name="name">
+      <alt>
+         <nonterminal name="namestart"/>
+         <repeat0>
+            <nonterminal name="namefollower"/>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark="-" name="namestart">
+      <alt>
+         <inclusion>
+            <literal string="_"/>
+            <class code="L"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule mark="-" name="namefollower">
+      <alt>
+         <nonterminal name="namestart"/>
+      </alt>
+      <alt>
+         <inclusion>
+            <literal string="-.·‿⁀"/>
+            <class code="Nd"/>
+            <class code="Mn"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule mark="-" name="tannotation">
+      <alt>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="pragma"/>
+                  <nonterminal name="sp"/>
+               </alt>
+            </alts>
+         </option>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="tmark"/>
+                  <nonterminal name="sp"/>
+               </alt>
+            </alts>
+         </option>
+      </alt>
+   </rule>
+   <rule mark="@" name="tmark">
+      <alt>
+         <inclusion>
+            <literal string="^-"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule mark="@" name="string">
+      <alt>
+         <literal tmark="-" string="&quot;"/>
+         <repeat1>
+            <nonterminal name="dchar"/>
+         </repeat1>
+         <literal tmark="-" string="&quot;"/>
+         <nonterminal name="s"/>
+      </alt>
+      <alt>
+         <literal tmark="-" string="'"/>
+         <repeat1>
+            <nonterminal name="schar"/>
+         </repeat1>
+         <literal tmark="-" string="'"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule name="dchar">
+      <alt>
+         <exclusion>
+            <literal string="&quot;"/>
+            <literal hex="a"/>
+            <literal hex="d"/>
+         </exclusion>
+      </alt>
+      <alt>
+         <literal string="&quot;"/>
+         <literal tmark="-" string="&quot;"/>
+      </alt>
+   </rule>
+   <comment>all characters except line breaks; quotes must be doubled</comment>
+   <rule name="schar">
+      <alt>
+         <exclusion>
+            <literal string="'"/>
+            <literal hex="a"/>
+            <literal hex="d"/>
+         </exclusion>
+      </alt>
+      <alt>
+         <literal string="'"/>
+         <literal tmark="-" string="'"/>
+      </alt>
+   </rule>
+   <comment>all characters except line breaks; quotes must be doubled</comment>
+   <rule mark="-" name="encoded">
+      <alt>
+         <nonterminal name="tannotation"/>
+         <literal tmark="-" string="#"/>
+         <nonterminal mark="@" name="hex"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule name="hex">
+      <alt>
+         <repeat1>
+            <inclusion>
+               <range from="0" to="9"/>
+               <range from="a" to="f"/>
+               <range from="A" to="F"/>
+            </inclusion>
+         </repeat1>
+      </alt>
+   </rule>
+   <rule mark="-" name="charset">
+      <alt>
+         <nonterminal name="inclusion"/>
+      </alt>
+      <alt>
+         <nonterminal name="exclusion"/>
+      </alt>
+   </rule>
+   <rule name="inclusion">
+      <alt>
+         <nonterminal name="tannotation"/>
+         <nonterminal name="set"/>
+      </alt>
+   </rule>
+   <rule name="exclusion">
+      <alt>
+         <nonterminal name="tannotation"/>
+         <literal tmark="-" string="~"/>
+         <nonterminal name="s"/>
+         <nonterminal name="set"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="set">
+      <alt>
+         <literal tmark="-" string="["/>
+         <nonterminal name="s"/>
+         <repeat0>
+            <nonterminal name="member"/>
+            <sep>
+               <alts>
+                  <alt>
+                     <inclusion tmark="-">
+                        <literal string=";|"/>
+                     </inclusion>
+                     <nonterminal name="s"/>
+                  </alt>
+               </alts>
+            </sep>
+         </repeat0>
+         <literal tmark="-" string="]"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="member">
+      <alt>
+         <nonterminal name="literal"/>
+      </alt>
+      <alt>
+         <nonterminal name="range"/>
+      </alt>
+      <alt>
+         <nonterminal name="class"/>
+      </alt>
+   </rule>
+   <rule name="range">
+      <alt>
+         <nonterminal name="from"/>
+         <nonterminal name="s"/>
+         <literal tmark="-" string="-"/>
+         <nonterminal name="s"/>
+         <nonterminal name="to"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule mark="@" name="from">
+      <alt>
+         <nonterminal name="character"/>
+      </alt>
+   </rule>
+   <rule mark="@" name="to">
+      <alt>
+         <nonterminal name="character"/>
+      </alt>
+   </rule>
+   <rule mark="-" name="character">
+      <alt>
+         <literal tmark="-" string="&quot;"/>
+         <nonterminal name="dchar"/>
+         <literal tmark="-" string="&quot;"/>
+      </alt>
+      <alt>
+         <literal tmark="-" string="'"/>
+         <nonterminal name="schar"/>
+         <literal tmark="-" string="'"/>
+      </alt>
+      <alt>
+         <literal string="#"/>
+         <nonterminal name="hex"/>
+      </alt>
+   </rule>
+   <rule name="class">
+      <alt>
+         <nonterminal name="code"/>
+         <nonterminal name="s"/>
+      </alt>
+   </rule>
+   <rule mark="@" name="code">
+      <alt>
+         <nonterminal name="capital"/>
+         <option>
+            <nonterminal name="letter"/>
+         </option>
+      </alt>
+   </rule>
+   <rule mark="-" name="capital">
+      <alt>
+         <inclusion>
+            <range from="A" to="Z"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule mark="-" name="letter">
+      <alt>
+         <inclusion>
+            <range from="a" to="z"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule name="pragma">
+      <alt>
+         <nonterminal name="pld"/>
+         <option>
+            <nonterminal mark="@" name="pmark"/>
+         </option>
+         <nonterminal mark="@" name="name"/>
+         <option>
+            <alts>
+               <alt>
+                  <nonterminal name="whitespace"/>
+                  <nonterminal name="pragma-data"/>
+               </alt>
+            </alts>
+         </option>
+         <nonterminal name="prd"/>
+      </alt>
+   </rule>
+   <comment>
+@pname: -QName; -UQName. 
+</comment>
+   <rule mark="@" name="pmark">
+      <alt>
+         <inclusion>
+            <literal string="@^?"/>
+         </inclusion>
+      </alt>
+   </rule>
+   <rule name="pragma-data">
+      <alt>
+         <repeat0>
+            <alts>
+               <alt>
+                  <nonterminal mark="-" name="pragma-char"/>
+               </alt>
+               <alt>
+                  <nonterminal mark="-" name="bracket-pair"/>
+               </alt>
+            </alts>
+         </repeat0>
+      </alt>
+   </rule>
+   <rule mark="-" name="pragma-char">
+      <alt>
+         <exclusion>
+            <literal string="{}"/>
+         </exclusion>
+      </alt>
+   </rule>
+   <rule mark="-" name="bracket-pair">
+      <alt>
+         <literal string="{"/>
+         <nonterminal mark="-" name="pragma-data"/>
+         <literal string="}"/>
+      </alt>
+   </rule>
+   <comment>
+-QName: -name, ':', -name.
+-UQName: 'Q
+      <comment>', -ns-name, '</comment>', -name.
+-ns-name: ~["
+      <comment/>"; '"'; "'"]* .
+</comment>
+   <rule mark="-" name="pld">
+      <alt>
+         <literal tmark="-" string="{["/>
+      </alt>
+   </rule>
+   <rule mark="-" name="prd">
+      <alt>
+         <literal tmark="-" string="]}"/>
+      </alt>
+   </rule>
+</ixml>

--- a/src/test/java/org/nineml/coffeefilter/ErrorTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ErrorTest.java
@@ -58,7 +58,7 @@ public class ErrorTest {
 
         try {
             ParserOptions options = new ParserOptions();
-            options.assertValidXmlNames = false;
+            options.setAssertValidXmlNames(false);
             DataTreeBuilder builder = new DataTreeBuilder(options);
             doc.getTree(builder);
             String json = builder.getTree().asJSON();

--- a/src/test/java/org/nineml/coffeefilter/HygieneTests.java
+++ b/src/test/java/org/nineml/coffeefilter/HygieneTests.java
@@ -1,0 +1,87 @@
+package org.nineml.coffeefilter;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.nineml.coffeegrinder.parser.Ambiguity;
+
+public class HygieneTests {
+
+    @Test
+    public void unreachableForbidden() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S: 'a'. B: 'b'.";
+
+        ParserOptions options = new ParserOptions();
+        options.setAllowUnreachableSymbols(false);
+        InvisibleXml invisibleXml = new InvisibleXml(options);
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+        Assertions.assertFalse(parser.constructed());
+    }
+
+    @Test
+    public void unreachableOk() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S: 'a'. B: 'b'.";
+
+        ParserOptions options = new ParserOptions();
+        options.setAllowUnreachableSymbols(true);
+        InvisibleXml invisibleXml = new InvisibleXml(options);
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+
+        input = "a";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        Assertions.assertTrue(doc.succeeded());
+    }
+
+    @Test
+    public void multipleForbidden() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S: 'a'. S: 'b'.";
+
+        ParserOptions options = new ParserOptions();
+        options.setAllowMultipleDefinitions(false);
+        InvisibleXml invisibleXml = new InvisibleXml(options);
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+        Assertions.assertFalse(parser.constructed());
+    }
+
+    @Test
+    public void multipleOk() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S: 'a'. S: 'b'.";
+
+        ParserOptions options = new ParserOptions();
+        options.setAllowMultipleDefinitions(true);
+        InvisibleXml invisibleXml = new InvisibleXml(options);
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+
+        input = "b";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        Assertions.assertTrue(doc.succeeded());
+    }
+
+    @Test
+    public void undefinedOk() {
+        // This test is for the bug where a terminal marked as optional was losing its optionality
+        String input = "S = A; B; '(', S, ')'.\n" +
+                "A = 'a'; X, A.\n" +
+                "B = 'b'; B, X*.\n";
+
+        ParserOptions options = new ParserOptions();
+        options.setAllowUndefinedSymbols(true);
+        InvisibleXml invisibleXml = new InvisibleXml(options);
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+
+        input = "b";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        Assertions.assertTrue(doc.succeeded());
+    }
+}

--- a/src/test/java/org/nineml/coffeefilter/PragmasTest.java
+++ b/src/test/java/org/nineml/coffeefilter/PragmasTest.java
@@ -1,15 +1,26 @@
 package org.nineml.coffeefilter;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.nineml.coffeegrinder.parser.Ambiguity;
+import org.nineml.coffeegrinder.parser.EarleyItem;
+import org.nineml.coffeegrinder.parser.ForestNode;
 
 import java.io.File;
 
 import static org.junit.Assert.fail;
 
 public class PragmasTest {
-    private static InvisibleXml invisibleXml = new InvisibleXml();
+    private ParserOptions options;
+    private InvisibleXml invisibleXml;
+
+    @Before
+    public void setup() {
+        options = new ParserOptions();
+        //options.getLogger().setDefaultLogLevel("debug");
+        invisibleXml = new InvisibleXml(options);
+    }
 
     @Test
     public void renameNonterminal() {
@@ -55,6 +66,103 @@ public class PragmasTest {
             InvisibleXmlDocument doc = parser.parse("b");
             String xml = doc.getTree();
             Assertions.assertEquals("<S><A>a'c</A></S>", xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void discardEmpty() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser();
+            InvisibleXmlDocument doc = parser.parse(new File("src/main/resources/org/nineml/coffeefilter/pragmas.ixml"));
+            String xml = doc.getTree();
+            Assertions.assertFalse(xml.contains("<prolog"));
+            xml = parser.getCompiledParser();
+            System.out.println(xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void discardNone() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/discard-empty.ixml"));
+            InvisibleXmlDocument doc = parser.parse("abcde");
+            String xml = doc.getTree();
+            Assertions.assertEquals("<S D=\"d\" E=\"e\"><A>a</A><B>b</B><C>c</C></S>", xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void discardA() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/discard-empty.ixml"));
+            InvisibleXmlDocument doc = parser.parse("cde");
+            String xml = doc.getTree();
+            Assertions.assertEquals("<S D=\"d\" E=\"e\"><B/><C>c</C></S>", xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void discardACD() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/discard-empty.ixml"));
+            InvisibleXmlDocument doc = parser.parse("");
+            String xml = doc.getTree();
+            Assertions.assertEquals("<S E=\"\"><B/></S>", xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void compilerTest() {
+        try {
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/discard-empty.ixml"));
+            String xml = parser.getCompiledParser();
+            System.out.println(xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void lettersOrNumbers() {
+        try {
+            ParserOptions options = new ParserOptions();
+            options.setPrettyPrint(true);
+            invisibleXml = new InvisibleXml(options);
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/letters-or-numbers.ixml"));
+            StringBuilder sb = new StringBuilder();
+            for (int count = 0; count < 20; count++) {
+                sb.append("abcde");
+                sb.append("01234");
+            }
+            InvisibleXmlDocument doc = parser.parse(sb.toString());
+            String xml = doc.getTree();
+            System.out.println(xml);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void unicodeData() {
+        try {
+            ParserOptions options = new ParserOptions();
+            options.setPrettyPrint(true);
+            invisibleXml = new InvisibleXml(options);
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("../pot/scraps/chars/unicode.ixml"));
+            InvisibleXmlDocument doc = parser.parse(new File("../pot/scraps/chars/MediumData.txt"));
+            //String xml = doc.getTree();
+            System.out.println(doc.succeeded());
+            System.out.println(EarleyItem.totalItems() + " / " + ForestNode.totalNodes());
         } catch (Exception ex) {
             fail();
         }

--- a/src/test/java/org/nineml/coffeefilter/PragmasTest.java
+++ b/src/test/java/org/nineml/coffeefilter/PragmasTest.java
@@ -78,8 +78,8 @@ public class PragmasTest {
             InvisibleXmlDocument doc = parser.parse(new File("src/main/resources/org/nineml/coffeefilter/pragmas.ixml"));
             String xml = doc.getTree();
             Assertions.assertFalse(xml.contains("<prolog"));
-            xml = parser.getCompiledParser();
-            System.out.println(xml);
+            //xml = parser.getCompiledParser();
+            //System.out.println(xml);
         } catch (Exception ex) {
             fail();
         }
@@ -121,37 +121,7 @@ public class PragmasTest {
         }
     }
 
-    @Test
-    public void compilerTest() {
-        try {
-            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/discard-empty.ixml"));
-            String xml = parser.getCompiledParser();
-            System.out.println(xml);
-        } catch (Exception ex) {
-            fail();
-        }
-    }
-
-    @Test
-    public void lettersOrNumbers() {
-        try {
-            ParserOptions options = new ParserOptions();
-            options.setPrettyPrint(true);
-            invisibleXml = new InvisibleXml(options);
-            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/letters-or-numbers.ixml"));
-            StringBuilder sb = new StringBuilder();
-            for (int count = 0; count < 20; count++) {
-                sb.append("abcde");
-                sb.append("01234");
-            }
-            InvisibleXmlDocument doc = parser.parse(sb.toString());
-            String xml = doc.getTree();
-            System.out.println(xml);
-        } catch (Exception ex) {
-            fail();
-        }
-    }
-
+    /*
     @Test
     public void unicodeData() {
         try {
@@ -162,10 +132,9 @@ public class PragmasTest {
             InvisibleXmlDocument doc = parser.parse(new File("../pot/scraps/chars/MediumData.txt"));
             //String xml = doc.getTree();
             System.out.println(doc.succeeded());
-            System.out.println(EarleyItem.totalItems() + " / " + ForestNode.totalNodes());
         } catch (Exception ex) {
             fail();
         }
     }
-
+     */
 }

--- a/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
+++ b/src/test/java/org/nineml/coffeefilter/SimpleTreeTest.java
@@ -214,7 +214,7 @@ public class SimpleTreeTest extends CommonBuilder {
     public void jsonAttributes() {
         try {
             ParserOptions options = new ParserOptions();
-            options.assertValidXmlNames = false;
+            options.setAssertValidXmlNames(false);
             SimpleTree tree = buildAttributesSimpleTree(options);
             String str = tree.asJSON();
             Assert.assertEquals("{\"content\":{\"name\":\"root\",\"attributes\":{\"count\":2,\"version\":1.0},\"content\":[{\"name\":\"record\",\"attributes\":{\"num\":1},\"content\":[{\"name\":\"name\",\"content\":\"John Doe\"},{\"name\":\"age\",\"content\":25}]},{\"name\":\"record\",\"content\":[{\"name\":\"name\",\"content\":\"Mary Smith\"},{\"name\":\"age\",\"content\":22}]},{\"name\":\"no-content\",\"attributes\":{\"test\":\"string\"}},{\"name\":\"no-content-or-attr\"}]}}",
@@ -228,7 +228,7 @@ public class SimpleTreeTest extends CommonBuilder {
     public void jsonRecords() {
         try {
             ParserOptions options = new ParserOptions();
-            options.assertValidXmlNames = false;
+            options.setAssertValidXmlNames(false);
             SimpleTree tree = buildRecordSimpleTree(options);
 
             String str = tree.asJSON();

--- a/src/test/java/org/nineml/coffeefilter/TestDriver.java
+++ b/src/test/java/org/nineml/coffeefilter/TestDriver.java
@@ -38,9 +38,9 @@ public class TestDriver {
     public static final QName t_app_info = new QName("t", xmlns_t, "app-info");
     public static final QName t_options = new QName("t", xmlns_t, "options");
     public static final QName ap_multiple_definitions = new QName("ap", xmlns_ap, "multiple-definitions");
-    public static final QName ap_undefined_nonterminals = new QName("ap", xmlns_ap, "undefined-nonterminals");
-    public static final QName ap_unreachable_rules = new QName("ap", xmlns_ap, "unreachable-rules");
-    public static final QName ap_unproductive_nonterminals = new QName("ap", xmlns_ap, "unproductive-nonterminals");
+    public static final QName ap_undefined_symbols = new QName("ap", xmlns_ap, "undefined-symbols");
+    public static final QName ap_unreachable_symbols = new QName("ap", xmlns_ap, "unreachable-symbols");
+    public static final QName ap_unproductive_symbols = new QName("ap", xmlns_ap, "unproductive-symbols");
     public static final QName _name = new QName("", "name");
     public static final QName _href = new QName("", "href");
     private static final String USAGE = "Usage: TestDriver [-s:set] [-t:test] [-e:exceptions] catalog.xml";
@@ -210,17 +210,17 @@ public class TestDriver {
             if (appInfo != null) {
                 Map<QName,String> okopts = supportedOptions(appInfo);
                 if (okopts != null) {
-                    System.err.println("Running with appinfo");
+                    System.err.println("Running with app-info");
                     boolean allowUndefinedSymbols = options.getAllowUndefinedSymbols();
                     boolean allowUnreachableSymbols = options.getAllowUnreachableSymbols();
                     boolean allowUnproductiveRules = options.getAllowUnproductiveSymbols();
                     boolean allowMultiple = options.getAllowMultipleDefinitions();
 
-                    options.setAllowUnreachableSymbols(!"error".equals(okopts.getOrDefault(ap_unreachable_rules, "error")));
-                    options.setAllowUnproductiveSymbols(!"error".equals(okopts.getOrDefault(ap_unproductive_nonterminals, "error")));
+                    options.setAllowUnreachableSymbols(!"error".equals(okopts.getOrDefault(ap_unreachable_symbols, "error")));
+                    options.setAllowUnproductiveSymbols(!"error".equals(okopts.getOrDefault(ap_unproductive_symbols, "error")));
                     options.setAllowMultipleDefinitions(!"error".equals(okopts.getOrDefault(ap_multiple_definitions, "error")));
                     // Last because it also enables unproductive nonterminals
-                    options.setAllowUndefinedSymbols(!"error".equals(okopts.getOrDefault(ap_undefined_nonterminals, "error")));
+                    options.setAllowUndefinedSymbols(!"error".equals(okopts.getOrDefault(ap_undefined_symbols, "error")));
 
                     if (t_grammar_test.equals(testCase.getNodeName())) {
                         doGrammarTest(config, testCase, appInfo);
@@ -233,7 +233,7 @@ public class TestDriver {
                     options.setAllowUnreachableSymbols(allowUnreachableSymbols);
                     options.setAllowMultipleDefinitions(allowMultiple);
                 } else {
-                    System.err.println("No appinfo options are possible");
+                    System.err.println("No app-info options are possible");
                 }
             }
         } catch (Exception ex) {
@@ -266,9 +266,9 @@ public class TestDriver {
                     XdmNode attr = aiter.next();
                     String value = attr.getStringValue();
                     if (ap_multiple_definitions.equals(attr.getNodeName())
-                            || ap_undefined_nonterminals.equals(attr.getNodeName())
-                            || ap_unproductive_nonterminals.equals(attr.getNodeName())
-                            || ap_unreachable_rules.equals(attr.getNodeName())) {
+                            || ap_undefined_symbols.equals(attr.getNodeName())
+                            || ap_unproductive_symbols.equals(attr.getNodeName())
+                            || ap_unreachable_symbols.equals(attr.getNodeName())) {
                         if ("error".equals(value) || "warning".equals(value) || "silence".equals(value)) {
                             opts.put(attr.getNodeName(), value);
                         } else {

--- a/src/test/java/org/nineml/coffeefilter/TestDriver.java
+++ b/src/test/java/org/nineml/coffeefilter/TestDriver.java
@@ -1,12 +1,11 @@
 package org.nineml.coffeefilter;
 
 import net.sf.saxon.lib.ErrorReporter;
-import net.sf.saxon.lib.Logger;
-import net.sf.saxon.lib.StandardErrorReporter;
 import net.sf.saxon.s9api.*;
 import org.nineml.coffeefilter.exceptions.IxmlException;
 import org.nineml.coffeefilter.trees.DataTree;
 import org.nineml.coffeefilter.trees.DataTreeBuilder;
+import org.nineml.coffeegrinder.exceptions.GrammarException;
 
 import java.io.*;
 import java.net.URI;
@@ -15,9 +14,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TestDriver {
     public static final String xmlns_t = "https://github.com/cmsmcq/ixml-tests";
+    public static final String xmlns_ap = "http://blackmesatech.com/2019/iXML/Aparecium";
     public static final QName t_test_catalog = new QName("t", xmlns_t, "test-catalog");
     public static final QName t_test_set = new QName("t", xmlns_t, "test-set");
     public static final QName t_test_set_ref = new QName("t", xmlns_t, "test-set-ref");
@@ -34,18 +35,24 @@ public class TestDriver {
     public static final QName t_assert_xml = new QName("t", xmlns_t, "assert-xml");
     public static final QName t_assert_not_a_grammar = new QName("t", xmlns_t, "assert-not-a-grammar");
     public static final QName t_assert_not_a_sentence = new QName("t", xmlns_t, "assert-not-a-sentence");
+    public static final QName t_app_info = new QName("t", xmlns_t, "app-info");
+    public static final QName t_options = new QName("t", xmlns_t, "options");
+    public static final QName ap_multiple_definitions = new QName("ap", xmlns_ap, "multiple-definitions");
+    public static final QName ap_undefined_nonterminals = new QName("ap", xmlns_ap, "undefined-nonterminals");
+    public static final QName ap_unreachable_rules = new QName("ap", xmlns_ap, "unreachable-rules");
+    public static final QName ap_unproductive_nonterminals = new QName("ap", xmlns_ap, "unproductive-nonterminals");
     public static final QName _name = new QName("", "name");
     public static final QName _href = new QName("", "href");
     private static final String USAGE = "Usage: TestDriver [-s:set] [-t:test] [-e:exceptions] catalog.xml";
 
     public static ParserOptions options = new ParserOptions();
-    public static InvisibleXml invisibleXml = new InvisibleXml(options);
     public static boolean runningEE = true;
     public static Processor processor = null;
     public static boolean ranOne = false;
     public static int attempts = 0;
     public static final TestReport report = new TestReport(options);
 
+    public InvisibleXml invisibleXml;
     public DataTree exceptions = null;
     public ArrayList<XdmNode> testsToRun = new ArrayList<>();
     public HashMap<XdmNode, TestConfiguration> testConfigurations = new HashMap<>();
@@ -73,12 +80,14 @@ public class TestDriver {
             } else if (arg.startsWith("-e:")) {
                 exfile = arg.substring(3);
             } else if ("--pedantic".equals(arg)) {
-                options.pedantic = true;
+                options.setPedantic(true);
             } else {
                 catalog = arg;
             }
             pos += 1;
         }
+
+        invisibleXml = new InvisibleXml(options);
 
         if (catalog == null) {
             System.err.println(USAGE);
@@ -196,18 +205,97 @@ public class TestDriver {
             } else {
                 doRunTest(config, testCase);
             }
+
+            XdmNode appInfo = appInfo(testCase);
+            if (appInfo != null) {
+                Map<QName,String> okopts = supportedOptions(appInfo);
+                if (okopts != null) {
+                    System.err.println("Running with appinfo");
+                    boolean allowUndefinedSymbols = options.getAllowUndefinedSymbols();
+                    boolean allowUnreachableSymbols = options.getAllowUnreachableSymbols();
+                    boolean allowUnproductiveRules = options.getAllowUnproductiveSymbols();
+                    boolean allowMultiple = options.getAllowMultipleDefinitions();
+
+                    options.setAllowUnreachableSymbols(!"error".equals(okopts.getOrDefault(ap_unreachable_rules, "error")));
+                    options.setAllowUnproductiveSymbols(!"error".equals(okopts.getOrDefault(ap_unproductive_nonterminals, "error")));
+                    options.setAllowMultipleDefinitions(!"error".equals(okopts.getOrDefault(ap_multiple_definitions, "error")));
+                    // Last because it also enables unproductive nonterminals
+                    options.setAllowUndefinedSymbols(!"error".equals(okopts.getOrDefault(ap_undefined_nonterminals, "error")));
+
+                    if (t_grammar_test.equals(testCase.getNodeName())) {
+                        doGrammarTest(config, testCase, appInfo);
+                    } else {
+                        doRunTest(config, testCase, appInfo);
+                    }
+
+                    options.setAllowUndefinedSymbols(allowUndefinedSymbols);
+                    options.setAllowUnproductiveSymbols(allowUnproductiveRules);
+                    options.setAllowUnreachableSymbols(allowUnreachableSymbols);
+                    options.setAllowMultipleDefinitions(allowMultiple);
+                } else {
+                    System.err.println("No appinfo options are possible");
+                }
+            }
         } catch (Exception ex) {
             System.err.println("EXCEPTION " + testCase.getAttributeValue(_name) + ": " + ex.getMessage());
         }
     }
 
-    private void doRunTest(TestConfiguration config, XdmNode testCase) throws IOException, URISyntaxException, SaxonApiException {
-        ranOne = true;
+    private XdmNode appInfo(XdmNode node) {
+        XdmSequenceIterator<XdmNode> iter = node.axisIterator(Axis.CHILD);
+        while (iter.hasNext()) {
+            XdmNode child = iter.next();
+            if (child.getNodeKind() == XdmNodeKind.ELEMENT
+                && t_app_info.equals(child.getNodeName())) {
+                return child;
+            }
+        }
+        return null;
+    }
 
+    private Map<QName,String> supportedOptions(XdmNode appInfo) {
+        XdmSequenceIterator<XdmNode> iter = appInfo.axisIterator(Axis.CHILD);
+        while (iter.hasNext()) {
+            XdmNode child = iter.next();
+            if (child.getNodeKind() == XdmNodeKind.ELEMENT
+                    && t_options.equals(child.getNodeName())) {
+                boolean ok = true;
+                HashMap<QName,String> opts = new HashMap<>();
+                XdmSequenceIterator<XdmNode> aiter = child.axisIterator(Axis.ATTRIBUTE);
+                while (aiter.hasNext()) {
+                    XdmNode attr = aiter.next();
+                    String value = attr.getStringValue();
+                    if (ap_multiple_definitions.equals(attr.getNodeName())
+                            || ap_undefined_nonterminals.equals(attr.getNodeName())
+                            || ap_unproductive_nonterminals.equals(attr.getNodeName())
+                            || ap_unreachable_rules.equals(attr.getNodeName())) {
+                        if ("error".equals(value) || "warning".equals(value) || "silence".equals(value)) {
+                            opts.put(attr.getNodeName(), value);
+                        } else {
+                            ok = false;
+                        }
+                    } else {
+                        ok = false;
+                    }
+                }
+                if (ok) {
+                    return opts;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void doRunTest(TestConfiguration config, XdmNode testCase) throws IOException, URISyntaxException, SaxonApiException {
         XdmNode result = config.find(testCase, t_result);
         if (result == null) {
             throw new RuntimeException("Test case has no result?: " + testCase.getAttributeValue(_name));
         }
+        doRunTest(config, testCase, result);
+    }
+
+    private void doRunTest(TestConfiguration config, XdmNode testCase, XdmNode result) throws IOException, URISyntaxException, SaxonApiException {
+        ranOne = true;
 
         List<XdmNode> assertions = config.findAll(result, t_assert_xml, t_assert_xml_ref, t_assert_not_a_grammar, t_assert_not_a_sentence);
         if (assertions.isEmpty()) {
@@ -241,7 +329,10 @@ public class TestDriver {
         if (result == null) {
             throw new RuntimeException("Test case has no result?: " + testCase.getAttributeValue(_name));
         }
+        doGrammarTest(config, testCase, result);
+    }
 
+    private void doGrammarTest(TestConfiguration config, XdmNode testCase, XdmNode result) throws IOException, URISyntaxException, SaxonApiException {
         List<XdmNode> assertions = config.findAll(result, t_assert_xml, t_assert_xml_ref, t_assert_not_a_grammar, t_assert_not_a_sentence);
         if (assertions.isEmpty()) {
             throw new RuntimeException("Test case makes no assertion?: " + testCase.getAttributeValue(_name));
@@ -316,8 +407,6 @@ public class TestDriver {
         if (same) {
             tresult.state = TestState.PASS;
         } else {
-            System.err.println("Actual result:");
-            System.err.println(node);
             tresult.state = TestState.FAIL;
         }
     }
@@ -395,6 +484,7 @@ public class TestDriver {
     }
 
     private InvisibleXmlParser loadGrammar(TestConfiguration config) throws IOException, URISyntaxException {
+        invisibleXml = new InvisibleXml(options);
         InvisibleXmlParser parser;
         String ixml;
         if (t_ixml_grammar.equals(config.grammar.getNodeName())) {
@@ -534,14 +624,23 @@ public class TestDriver {
             throw new RuntimeException("Unexpected test string: " + testString.getNodeName());
         }
 
-        InvisibleXmlDocument doc = parser.parse(input);
-        result.documentParseTime = doc.parseTime();
-
-        if (doc.getNumberOfParses() == 0) {
-            result.state = TestState.PASS;
-        } else {
+        try {
+            InvisibleXmlDocument doc = parser.parse(input);
+            result.documentParseTime = doc.parseTime();
+            if (doc.getNumberOfParses() == 0) {
+                result.state = TestState.PASS;
+            } else {
+                result.state = TestState.FAIL;
+                result.xml = doc.getTree();
+            }
+        } catch (GrammarException ex) {
+            for (XdmNode assertion : assertions) {
+                if (t_assert_not_a_sentence.equals(assertion.getNodeName())) {
+                    result.state = TestState.PASS;
+                    return;
+                }
+            }
             result.state = TestState.FAIL;
-            result.xml = doc.getTree();
         }
     }
 

--- a/src/test/java/org/nineml/coffeefilter/TestReport.java
+++ b/src/test/java/org/nineml/coffeefilter/TestReport.java
@@ -101,7 +101,7 @@ public class TestReport {
     }
 
     public void finished() {
-        if (options.pedantic) {
+        if (options.getPedantic()) {
             System.err.printf("Passed %d of %d tests (pedantically).%n", passed, testsToRun);
         } else {
             System.err.printf("Passed %d of %d tests.%n", passed, testsToRun);

--- a/src/test/resources/discard-empty.ixml
+++ b/src/test/resources/discard-empty.ixml
@@ -1,0 +1,10 @@
+S: {[nineml discard empty]} A,
+                            B,
+   {[nineml discard empty]} C,
+   {[nineml discard empty]} @D,
+                            @E .
+A: 'a'? .
+B: 'b'? .
+C: 'c'? .
+D: 'd'? .
+E: 'e'? .

--- a/src/test/resources/letters-or-numbers.ixml
+++ b/src/test/resources/letters-or-numbers.ixml
@@ -1,0 +1,5 @@
+String: Numbers, String; Letters, String; Numbers; Letters .
+Letters: letter+ .
+Numbers: number+ .
+-number: ["0"-"9"] .
+-letter: ~["0"-"9"] .

--- a/src/test/resources/test-suite-exceptions
+++ b/src/test/resources/test-suite-exceptions
@@ -1,2 +1,4 @@
 set "expr1"
-    case "expr1" because Its output is not valid XML.
+    case "expr1" because its output is not valid XML.
+set "range"
+    case "range" because the test is incorrect, waiting for PR to be accepted.


### PR DESCRIPTION
1. The `ParserOptions` API now has getters and setters
2. Reworked some aspects of pragma processing
3. Tweaked the way options are passed around
4. Updated and improved the test driver, support for Aparecium hygiene options