### PR TITLE
Bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=1.99.2
+filterVersion=1.99.3
 
 grinderName=coffeegrinder
-grinderVersion=1.99.2
+grinderVersion=1.99.3
 
 xmlresolverVersion=4.3.0
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXml.java
@@ -233,7 +233,7 @@ public class InvisibleXml {
             SourceGrammar grammar = compiler.parse(stream, systemId);
             Ixml ixml = new Ixml(options, grammar);
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
-            return new InvisibleXmlParser(ixml, parseMillis);
+            return new InvisibleXmlParser(ixml, options, parseMillis);
         } catch (CoffeeGrinderException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
         }
@@ -258,7 +258,7 @@ public class InvisibleXml {
             parser.parse(stream, handler, systemId);
             Ixml ixml = handler.getIxml();
             long parseMillis = Calendar.getInstance().getTimeInMillis() - startMillis;
-            return new InvisibleXmlParser(ixml, parseMillis);
+            return new InvisibleXmlParser(ixml, options, parseMillis);
         } catch (ParserConfigurationException|SAXException ex) {
             throw IxmlException.failedtoParse(systemId, ex);
         } catch (CoffeeGrinderException ex) {
@@ -276,29 +276,24 @@ public class InvisibleXml {
      */
     public InvisibleXmlParser getParserFromIxml(InputStream stream, String charset) throws IOException {
         InvisibleXmlParser ixmlParser = getParser();
-        //ixmlParser.setOptions(options);
 
         InvisibleXmlDocument doc = ixmlParser.parse(stream, charset);
         if (doc.getNumberOfParses() == 0) {
-            return new InvisibleXmlParser(doc, doc.parseTime());
+            return new InvisibleXmlParser(doc, options, doc.parseTime());
         }
-
-        //ParseTree tree = doc.getResult().getTree();
 
         ParserOptions builderOptions = new ParserOptions(options);
         builderOptions.setShowMarks(false);
         builderOptions.setShowBnfNonterminals(false);
         builderOptions.setAssertValidXmlNames(false);
         builderOptions.setAssertValidXmlCharacters(true);
-        //CommonBuilder builder = new CommonBuilder(tree, ixmlParser.getIxmlVersion(), doc.getResult(), builderOptions);
 
         try {
-            IxmlContentHandler handler = new IxmlContentHandler(options);
-            doc.getTree(handler);
-            //builder.build(handler);
+            IxmlContentHandler handler = new IxmlContentHandler(builderOptions);
+            doc.getTree(handler, builderOptions);
             Ixml ixml = handler.getIxml();
 
-            InvisibleXmlParser parser = new InvisibleXmlParser(ixml, doc.getResult().getParseTime());
+            InvisibleXmlParser parser = new InvisibleXmlParser(ixml, options, doc.getResult().getParseTime());
 
             HygieneReport report = parser.getHygieneReport();
             if (!report.isClean()) {

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlDocument.java
@@ -184,12 +184,16 @@ public class InvisibleXmlDocument {
     }
 
     /**
-     * Process the result with your own {@link TreeBuilder}.
+     * Process the result with your own {@link EventBuilder}.
+     * <p>This API needs work. It should allow a {@link TreeBuilder}, but it needs the SAX handler
+     * to generate the error document.</p>
      * @param builder the tree builder.
      */
-    public void getTree(TreeBuilder builder) {
+    public void getTree(EventBuilder builder) {
         if (result.succeeded() || (result.prefixSucceeded() && prefixOk)) {
             result.getTree(builder);
+        } else {
+            realizeErrorDocument(builder.getHandler());
         }
     }
 

--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -29,33 +29,31 @@ public class InvisibleXmlParser {
     private Exception exception = null;
     private HygieneReport hygieneReport = null;
     private boolean shownMessage = false;
-    private CompiledGrammar grammar = null;
 
-    protected InvisibleXmlParser(Ixml ixml) {
+    protected InvisibleXmlParser(Ixml ixml, ParserOptions options) {
         this.ixml = ixml;
         this.parseTime = -1;
         failedParse = null;
-        options = ixml.getOptions();
-        options.getLogger().setDefaultLogLevel(Logger.INFO);
+        this.options = options;
     }
 
-    protected InvisibleXmlParser(Ixml ixml, long parseMillis) {
+    protected InvisibleXmlParser(Ixml ixml, ParserOptions options, long parseMillis) {
         this.ixml = ixml;
         this.parseTime = parseMillis;
         failedParse = null;
-        options = ixml.getOptions();
+        this.options = options;
     }
 
-    protected InvisibleXmlParser(InvisibleXmlDocument failed, long parseMillis) {
+    protected InvisibleXmlParser(InvisibleXmlDocument failed, ParserOptions options, long parseMillis) {
         ixml = null;
         parseTime = parseMillis;
         failedParse = failed;
-        options = failed.getOptions();
+        this.options = options;
         options.getLogger().setDefaultLogLevel(Logger.INFO);
     }
 
     protected InvisibleXmlParser(InvisibleXmlDocument failed, Exception exception, long parseMillis) {
-        this(failed, parseMillis);
+        this(failed, failed.getOptions(), parseMillis);
         this.exception = exception;
     }
 

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -258,38 +258,6 @@ public class Ixml extends XNonterminal {
     private void constructGrammar(ParserOptions options) {
         grammar = new SourceGrammar(options);
 
-        /*
-        ArrayList<IPragma> grammarPragmas = new ArrayList<>();
-
-        // Process pragmas on rules first...
-        for (XNode child : children) {
-            if (child instanceof IRule) {
-                IRule rule = (IRule) child;
-                if (startRule.equals(rule.getName())) {
-                    for (IPragma pragma : pragmas) {
-                        if (pragma instanceof IPragmaXmlns) {
-                            grammarPragmas.add(pragma);
-                        } else {
-                            options.getLogger().debug(logcategory, "Unknown pragma, or does not apply in the prologue: %s", pragma);
-                        }
-                    }
-                }
-
-                for (IPragma pragma : rule.pragmas) {
-                    if (pragma instanceof IPragmaRegex) {
-                        attributes.add(new ParserAttribute("regex", pragma.getPragmaData()));
-                    } else if (pragma instanceof IPragmaPriority) {
-                        attributes.add(new ParserAttribute("priority", pragma.getPragmaData()));
-                    } else {
-                        options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to rule: %s", pragma);
-                    }
-                }
-
-            }
-        }
-
-         */
-
         ArrayList<ParserAttribute> attributes = new ArrayList<>();
         for (XNode child : children) {
             if (child instanceof IRule) {
@@ -384,6 +352,8 @@ public class Ixml extends XNonterminal {
                         for (IPragma pragma : cat.pragmas) {
                             if (pragma instanceof IPragmaRewrite) {
                                 rewrite = (IPragmaRewrite) pragma;
+                            } else if (pragma instanceof IPragmaPriority) {
+                                // nop
                             } else {
                                 options.getLogger().debug(logcategory, "Unknown pragma, or does not apply to a literal: %s", pragma);
                             }

--- a/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
@@ -57,6 +57,10 @@ public class EventBuilder extends TreeBuilder {
         this.handler = handler;
     }
 
+    public ContentHandler getHandler() {
+        return handler;
+    }
+
     @Override
     public int chooseFromRemaining(List<RuleChoice> alternatives) {
         ambiguous = true;
@@ -369,16 +373,19 @@ public class EventBuilder extends TreeBuilder {
                         handler.startPrefixMapping(InvisibleXml.nineml_prefix, InvisibleXml.nineml_ns);
                     }
 
-                    boolean okVersion = "1.0".equals(grammarVersion)
-                            || "1.0-9ml".equals(grammarVersion)
-                            || "1.0-nineml".equals(grammarVersion);
+                    boolean badVersion = !"1.0".equals(grammarVersion)
+                            && !"1.0-9ml".equals(grammarVersion)
+                            && !"1.0-nineml".equals(grammarVersion);
 
-                    if (ambiguous || !okVersion) {
+                    ambiguous = ambiguous && !options.isSuppressedState("ambiguous");
+                    badVersion = badVersion && !options.isSuppressedState("version-mismatch");
+
+                    if (ambiguous || badVersion) {
                         handler.startPrefixMapping(InvisibleXml.ixml_prefix, InvisibleXml.ixml_ns);
                     }
 
                     String state = ambiguous ? "ambiguous" : "";
-                    if (!okVersion) {
+                    if (badVersion) {
                         state += ("".equals(state) ? "" : " ") + "version-mismatch";
                     }
 

--- a/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
@@ -161,15 +161,43 @@ public class EventBuilder extends TreeBuilder {
             }
         }
 
-        final String mark = getAttributeValue(attributes, "mark", "^");
+        String name = getAttributeValue(attributes, "name", symbol.toString());
+        String mark = getAttributeValue(attributes, "mark", "^");
+        String origName = null;
+        String origMark = null;
+
+        if (options.getShowMarks() || options.getShowBnfNonterminals()) {
+            String pruneStr = getAttributeValue(attributes, ParserAttribute.PRUNING, ParserAttribute.PRUNING_FORBIDDEN.getValue());
+            boolean prune = ParserAttribute.PRUNING_ALLOWED.getValue().equals(pruneStr);
+            boolean showHidden = options.getShowBnfNonterminals() && prune;
+            boolean showMarks = options.getShowMarks() && (!prune || showHidden);
+
+            if (showMarks) {
+                origMark = mark;
+                mark = "^";
+            }
+
+            if (showHidden) {
+                origName = name;
+                name = "n:symbol";
+            }
+        }
+
         if ("-".equals(mark)) {
             return;
         }
 
-        String name = getAttributeValue(attributes, "name", symbol.toString());
         Element element = new Element(mark, name, depth);
         element.discardEmpty = "empty".equals(getAttributeValue(attributes, "discard", "none"));
         output.push(element);
+
+        // The else/if is on purpose here, we need mark to be ^ to show hidden nonterminals,
+        // but there's no point in outputting the mark as it's always '-'.
+        if (origName != null) {
+            output.push(new Attribute(InvisibleXml.nineml_prefix + ":name", origName));
+        } else if (origMark != null) {
+            output.push(new Attribute(InvisibleXml.ixml_prefix + ":mark", origMark));
+        }
     }
 
     @Override
@@ -178,13 +206,29 @@ public class EventBuilder extends TreeBuilder {
             return;
         }
 
-        final String mark = getAttributeValue(attributes, "mark", "^");
+        String name = getAttributeValue(attributes, "name", symbol.toString());
+        String mark = getAttributeValue(attributes, "mark", "^");
+
+        if (options.getShowMarks() || options.getShowBnfNonterminals()) {
+            String pruneStr = getAttributeValue(attributes, ParserAttribute.PRUNING, ParserAttribute.PRUNING_FORBIDDEN.getValue());
+            boolean prune = ParserAttribute.PRUNING_ALLOWED.getValue().equals(pruneStr);
+            boolean showHidden = options.getShowBnfNonterminals() && prune;
+            boolean showMarks = options.getShowMarks() && (!prune || showHidden);
+
+            if (showMarks) {
+                mark = "^";
+            }
+
+            if (showHidden) {
+                name = "n:symbol";
+            }
+        }
+
         if ("-".equals(mark)) {
             depth--;
             return;
         }
 
-        String name = getAttributeValue(attributes, "name", symbol.toString());
         // Move my element and my children onto a new stack so that popping them will be in the right order
         Stack<Child> local = new Stack<>();
         Child child = output.pop();
@@ -317,6 +361,14 @@ public class EventBuilder extends TreeBuilder {
                         handler.startPrefixMapping("", xmlns);
                     }
 
+                    if (options.getShowMarks()) {
+                        handler.startPrefixMapping(InvisibleXml.ixml_prefix, InvisibleXml.ixml_ns);
+                    }
+
+                    if (options.getShowBnfNonterminals()) {
+                        handler.startPrefixMapping(InvisibleXml.nineml_prefix, InvisibleXml.nineml_ns);
+                    }
+
                     boolean okVersion = "1.0".equals(grammarVersion)
                             || "1.0-9ml".equals(grammarVersion)
                             || "1.0-nineml".equals(grammarVersion);
@@ -388,9 +440,17 @@ public class EventBuilder extends TreeBuilder {
         }
     }
     private static class Attribute extends Child {
+        public final String namespace;
         public final String name;
         public final String value;
+        public Attribute(String namespace, String name, String value) {
+            this.namespace = namespace;
+            this.name = name;
+            this.value = value;
+        }
+
         public Attribute(String name, String value) {
+            this.namespace = null;
             this.name = name;
             this.value = value;
         }

--- a/src/test/java/org/nineml/coffeefilter/OutputTest.java
+++ b/src/test/java/org/nineml/coffeefilter/OutputTest.java
@@ -19,6 +19,26 @@ public class OutputTest {
     }
 
     @Test
+    public void showMarksTest() {
+        String ixml = "S = (A | B)+. A = 'a'. B = 'b'.";
+
+        ParserOptions options = new ParserOptions();
+        options.setShowMarks(true);
+        InvisibleXmlParser parser = new InvisibleXml(options).getParserFromIxml(ixml);
+        InvisibleXmlDocument doc = parser.parse("aa");
+        String xml = doc.getTree();
+        System.out.println(xml);
+        Assertions.assertEquals("<S xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:mark=\"^\"><A ixml:mark=\"^\">a</A><A ixml:mark=\"^\">a</A></S>", xml);
+
+        options.setShowBnfNonterminals(true);
+        parser = new InvisibleXml(options).getParserFromIxml(ixml);
+        doc = parser.parse("aa");
+        xml = doc.getTree();
+        System.out.println(xml);
+        Assertions.assertTrue(xml.startsWith("<n:symbol"));
+    }
+
+    @Test
     public void getTreeOutputTest() {
         String ixml = "S = A, B. A = 'a'. B = 'b'.";
         InvisibleXmlParser parser = new InvisibleXml().getParserFromIxml(ixml);


### PR DESCRIPTION
* Restore the feature that allows you to display marks and hidden noterminals
* Restore support for suppressing ixml:state values
* Remove some dead code, fix a bogus error message associated with the priority pragma
* Hack `getTree()` because I need the handler to build the error document