### PR TITLE
Refactoring and improvements for CoffeeGrinder 1.99.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=1.99.3
+filterVersion=1.99.4
 
 grinderName=coffeegrinder
-grinderVersion=1.99.3
+grinderVersion=1.99.4
 
 xmlresolverVersion=4.3.0
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -26,7 +26,7 @@ public class Ixml extends XNonterminal {
     protected final ParserOptions options;
     protected final HashMap<String,String> ixmlns;
     private SourceGrammar grammar = null;
-    protected boolean emptyProduction = false;
+    protected IRule emptyProduction = null;
     protected String version = "1.0";
 
     /**

--- a/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/utils/EventBuilder.java
@@ -57,6 +57,11 @@ public class EventBuilder extends TreeBuilder {
         this.handler = handler;
     }
 
+    public void setAmbiguous(boolean ambiguous, boolean infinitelyAmbiguous) {
+        this.ambiguous = ambiguous;
+        this.infinitelyAmbiguous = infinitelyAmbiguous;
+    }
+
     public ContentHandler getHandler() {
         return handler;
     }

--- a/src/test/java/org/nineml/coffeefilter/HygieneTests.java
+++ b/src/test/java/org/nineml/coffeefilter/HygieneTests.java
@@ -3,7 +3,6 @@ package org.nineml.coffeefilter;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.nineml.coffeefilter.exceptions.IxmlException;
-import org.nineml.coffeegrinder.parser.Ambiguity;
 
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/nineml/coffeefilter/OutputTest.java
+++ b/src/test/java/org/nineml/coffeefilter/OutputTest.java
@@ -27,14 +27,14 @@ public class OutputTest {
         InvisibleXmlParser parser = new InvisibleXml(options).getParserFromIxml(ixml);
         InvisibleXmlDocument doc = parser.parse("aa");
         String xml = doc.getTree();
-        System.out.println(xml);
+        //System.out.println(xml);
         Assertions.assertEquals("<S xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:mark=\"^\"><A ixml:mark=\"^\">a</A><A ixml:mark=\"^\">a</A></S>", xml);
 
         options.setShowBnfNonterminals(true);
         parser = new InvisibleXml(options).getParserFromIxml(ixml);
         doc = parser.parse("aa");
         xml = doc.getTree();
-        System.out.println(xml);
+        //System.out.println(xml);
         Assertions.assertTrue(xml.startsWith("<n:symbol"));
     }
 

--- a/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ParserFailTest.java
@@ -41,8 +41,13 @@ public class ParserFailTest {
                 Assert.assertTrue(str.contains("<line>1</line>"));
                 Assert.assertTrue(str.contains("<column>5</column>"));
                 Assert.assertTrue(str.contains("<pos>4</pos>"));
-                Assert.assertTrue(str.contains("<unexpected>J</unexpected>"));
                 Assert.assertTrue(str.contains("<permitted>' ', 'A', 'D', 'F', 'J', 'M', 'N', 'O', 'S'</permitted>"));
+            }
+            if (doc.getParserType() == ParserType.GLL) {
+                Assert.assertTrue(str.contains("<line>1</line>"));
+                Assert.assertTrue(str.contains("<column>5</column>"));
+                Assert.assertTrue(str.contains("<pos>5</pos>"));
+                Assert.assertTrue(str.contains("<unexpected>i</unexpected>"));
             }
         } catch (SaxonApiException ex) {
             System.err.println(ex.getMessage());

--- a/src/test/java/org/nineml/coffeefilter/ParserTest.java
+++ b/src/test/java/org/nineml/coffeefilter/ParserTest.java
@@ -145,7 +145,9 @@ public class ParserTest {
             InvisibleXmlParser parser = invisibleXml.getParser(new File("ixml/tests/ambiguous/ambig2.ixml"));
             String input = "";
             InvisibleXmlDocument doc = parser.parse(input);
-            Assert.assertEquals("<a/>", doc.getTree());
+            String xml = doc.getTree();
+            Assert.assertTrue(xml.startsWith("<a"));
+            Assert.assertTrue(xml.endsWith("/>"));
         } catch (Exception ex) {
             System.err.println(ex.getMessage());
             fail();

--- a/src/test/java/org/nineml/coffeefilter/PragmasTest.java
+++ b/src/test/java/org/nineml/coffeefilter/PragmasTest.java
@@ -3,9 +3,6 @@ package org.nineml.coffeefilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.nineml.coffeegrinder.parser.Ambiguity;
-import org.nineml.coffeegrinder.parser.EarleyItem;
-import org.nineml.coffeegrinder.parser.ForestNode;
 
 import java.io.File;
 

--- a/src/test/java/org/nineml/coffeefilter/TestDriver.java
+++ b/src/test/java/org/nineml/coffeefilter/TestDriver.java
@@ -873,7 +873,7 @@ public class TestDriver {
                     boolean processCase = false;
                     if (caseName == null || caseName.equals(thisCase)) {
                         processCase = true;
-                        if (caseName == null && dataSet != null) {
+                        if (caseName == null && dataSet != null && thisCase != null) {
                             for (DataTree excase : dataSet.getAll("case")) {
                                 if (thisCase.equals(excase.get("id").getValue())) {
                                     processCase = false;

--- a/src/test/java/org/nineml/coffeefilter/UnicodeTest.java
+++ b/src/test/java/org/nineml/coffeefilter/UnicodeTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.nineml.coffeegrinder.parser.ParserType;
+import org.nineml.coffeegrinder.util.DefaultProgressMonitor;
 import org.nineml.logging.Logger;
 
 import java.io.File;
@@ -24,8 +25,10 @@ public class UnicodeTest {
     public void small() {
         try {
             //invisibleXml.getOptions().getLogger().setDefaultLogLevel(Logger.DEBUG);
+            //invisibleXml.getOptions().setParserType("GLL");
+            //invisibleXml.getOptions().setProgressMonitor(new DefaultProgressMonitor());
             InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/unicode.ixml"));
-            InvisibleXmlDocument doc = parser.parse(new File("src/test/resources/TestData.txt"));
+            InvisibleXmlDocument doc = parser.parse(new File("src/test/resources/SmallData.txt"));
             Assert.assertTrue(doc.succeeded());
         } catch (Exception ex) {
             System.err.println(ex.getMessage());


### PR DESCRIPTION
* Some fiddling with line and column numbers which will probably be bogus for GLL
* Some fiddling with ambiguity
* Changed the rewrite rules so that `()?` is treated like `()`. Otherwise, you get two paths to ε which results in bogus ambiguity results
