### PR TITLE
Bump version for parity with CoffeeGrinder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=1.99.6
+filterVersion=1.99.7
 
 grinderName=coffeegrinder
-grinderVersion=1.99.6
+grinderVersion=1.99.7
 
 xmlresolverVersion=4.3.0
 docbookVersion=5.2b12


### PR DESCRIPTION
I'm not sure this is really necessary, but it's probably less confusing.