### PR TITLE
Fix pragma syntax

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=1.99.10
+filterVersion=1.99.11
 
 grinderName=coffeegrinder
 grinderVersion=1.99.11

--- a/src/main/java/org/nineml/coffeefilter/model/IPragma.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IPragma.java
@@ -11,7 +11,7 @@ public class IPragma extends XNonterminal {
         pragmaData = data;
     }
 
-    protected String getPragmaData() {
+    public String getPragmaData() {
         return pragmaData;
     }
 

--- a/src/main/java/org/nineml/coffeefilter/model/IPragmaMetadata.java
+++ b/src/main/java/org/nineml/coffeefilter/model/IPragmaMetadata.java
@@ -1,0 +1,22 @@
+package org.nineml.coffeefilter.model;
+
+public class IPragmaMetadata extends IPragma {
+    protected final String uri;
+    public IPragmaMetadata(XNode parent, String uri, String data) {
+        super(parent, "metadata");
+        this.uri = uri;
+        pragmaData = data;
+    }
+
+    public String getPragmaURI() {
+        return uri;
+    }
+
+    @Override
+    public String toString() {
+        if (pragmaData == null || "".equals(pragmaData)) {
+            return "{[" + name + " " + uri + "]}";
+        }
+        return "{[" + name + " " + uri + " " + pragmaData + "]}";
+    }
+}

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -25,6 +25,7 @@ public class Ixml extends XNonterminal {
     private final String startRule = "$$";
     protected final ParserOptions options;
     protected final HashMap<String,String> ixmlns;
+    protected final HashMap<String,String> pragmaDecl;
     private SourceGrammar grammar = null;
     protected IRule emptyProduction = null;
     protected String version = "1.0";
@@ -37,6 +38,7 @@ public class Ixml extends XNonterminal {
         super(null, "ixml", "$$_ixml");
         this.options = options;
         ixmlns = new HashMap<>();
+        pragmaDecl = new HashMap<>();
 
         if (options.getRuleRewriter() == null) {
             if ("GLL".equals(options.getParserType())) {
@@ -63,6 +65,7 @@ public class Ixml extends XNonterminal {
         grammarRules.addAll(grammar.getRules());
         this.options = options;
         ixmlns = new HashMap<>();
+        pragmaDecl = new HashMap<>();
 
         if (options.getRuleRewriter() == null) {
             if ("GLL".equals(options.getParserType())) {

--- a/src/main/resources/org/nineml/coffeefilter/pragmas.ixml
+++ b/src/main/resources/org/nineml/coffeefilter/pragmas.ixml
@@ -77,11 +77,10 @@ ixml version "1.0".
       -letter: ["a"-"z"].
     insertion: -"+", s, (string; -"#", hex), s.
 
-       pragma: -"{[", @pmark?, @pname, (whitespace, pragma-data)?, -"]}" . 
-      ppragma: -"{[+", @pmark?, @pname, (whitespace, pragma-data)?, -"]}" . 
-       @pname: -QName; -UQName. 
+       pragma: -"{[", @pname, (whitespace, pragma-data)?, -"]}" . 
+      ppragma: -"{[+", @pname, (whitespace, pragma-data)?, -"]}" . 
+       @pname: name.
 
-       @pmark: ["@^?"].
   pragma-data: (-pragma-char; -bracket-pair)*.
  -pragma-char: ~["{}"].
 -bracket-pair: '{', -pragma-data, '}'.

--- a/src/main/resources/org/nineml/coffeefilter/pragmas.xml
+++ b/src/main/resources/org/nineml/coffeefilter/pragmas.xml
@@ -622,9 +622,6 @@
    <rule name="pragma">
       <alt>
          <literal tmark="-" string="{["/>
-         <option>
-            <nonterminal mark="@" name="pmark"/>
-         </option>
          <nonterminal mark="@" name="pname"/>
          <option>
             <alts>
@@ -640,9 +637,6 @@
    <rule name="ppragma">
       <alt>
          <literal tmark="-" string="{[+"/>
-         <option>
-            <nonterminal mark="@" name="pmark"/>
-         </option>
          <nonterminal mark="@" name="pname"/>
          <option>
             <alts>
@@ -657,17 +651,7 @@
    </rule>
    <rule mark="@" name="pname">
       <alt>
-         <nonterminal mark="-" name="QName"/>
-      </alt>
-      <alt>
-         <nonterminal mark="-" name="UQName"/>
-      </alt>
-   </rule>
-   <rule mark="@" name="pmark">
-      <alt>
-         <inclusion>
-            <member string="@^?"/>
-         </inclusion>
+         <nonterminal name="name"/>
       </alt>
    </rule>
    <rule name="pragma-data">

--- a/src/test/java/org/nineml/coffeefilter/AmbiguityTest.java
+++ b/src/test/java/org/nineml/coffeefilter/AmbiguityTest.java
@@ -24,7 +24,7 @@ public class AmbiguityTest {
     @Test
     public void ambiguity1() {
         // This test is for the bug where a terminal marked as optional was losing its optionality
-        String input = "{[+ixmlns:n \"https://nineml.org/ns\"]} S = 'x', (A | {[n:priority 2]} B), 'y'.  {[n:priority 1]} A = 'a' | B. B = 'b' | A.";
+        String input = "{[+pragma n \"https://nineml.org/ns/pragma/\"]} S = 'x', (A | {[n priority 2]} B), 'y'.  {[n priority 1]} A = 'a' | B. B = 'b' | A.";
 
         InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
         input = "xay";

--- a/src/test/java/org/nineml/coffeefilter/PragmasTest.java
+++ b/src/test/java/org/nineml/coffeefilter/PragmasTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.fail;
 
@@ -25,6 +27,8 @@ public class PragmasTest {
         try {
             //invisibleXml.getOptions().getLogger().setDefaultLogLevel("debug");
             InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/two-dates.ixml"));
+            Map<String, List<String>> meta = parser.getMetadata();
+            Assertions.assertEquals(meta.get("http://purl.org/dc/elements/1.1/creator").get(0), "Norman Walsh");
             InvisibleXmlDocument doc = parser.parse("1999-12-31");
             String xml = doc.getTree();
             Assertions.assertEquals("<input><year>1999</year><month>12</month><day>31</day></input>", xml);
@@ -81,7 +85,7 @@ public class PragmasTest {
     public void discardEmpty() {
         try {
             String grammar1 = "S = A, B, C. A = 'a'. B='b'?. C='c'.";
-            String grammar2 = "{[+ixmlns:n \"https://nineml.org/ns\"]} S = A, {[n:discard empty]} B, C. A = 'a'. B='b'?. C='c'.";
+            String grammar2 = "{[+pragma n \"https://nineml.org/ns/pragma/\"]} S = A, {[n discard empty]} B, C. A = 'a'. B='b'?. C='c'.";
             String input = "ac";
 
             InvisibleXmlParser parser = invisibleXml.getParserFromIxml(grammar1);

--- a/src/test/resources/discard-empty.ixml
+++ b/src/test/resources/discard-empty.ixml
@@ -1,9 +1,9 @@
-{[+ixmlns:n "https://nineml.org/ns"]}
+{[+pragma n "https://nineml.org/ns/pragma/"]}
 
-S: {[n:discard empty]} A,
+S: {[n discard empty]} A,
                        B,
-   {[n:discard empty]} C,
-   {[n:discard empty]} @D,
+   {[n discard empty]} C,
+   {[n discard empty]} @D,
                        @E .
 A: 'a'? .
 B: 'b'? .

--- a/src/test/resources/malformed-test.ixml
+++ b/src/test/resources/malformed-test.ixml
@@ -1,5 +1,5 @@
-{[+ixmlns:n "https://nineml.org/ns"]}
-{[+ixmlns:o "http://example.com"]}
-{[+n:ns "http://example.com/]}                 { <-- syntax error }
-{[o:rule-pragma]}S: {[o:nonterminal-pragma]}A.
-A: ('a'; {[n:rewrite "a'c"]} 'b')+ .
+{[+pragma n "https://nineml.org/ns/pragma/"]}
+{[+pragma o "http://example.com"]}
+{[+n ns "http://example.com/]}                 { <-- syntax error }
+{[o rule-pragma]}S: {[o nonterminal-pragma]}A.
+A: ('a'; {[n rewrite "a'c"]} 'b')+ .

--- a/src/test/resources/two-dates.ixml
+++ b/src/test/resources/two-dates.ixml
@@ -1,13 +1,22 @@
+{[+pragma rename "https://nineml.org/ns/pragma/rename"]}
+{[+pragma rewrite "https://nineml.org/ns/pragma/rewrite"]}
+{[+pragma dc "http://purl.org/dc/elements/1.1/"]}
+{[+pragma opts "https://nineml.org/ns/pragma/options/"]}
+{[+pragma date "http://purl.org/dc/elements/1.1/date"]}
+{[+dc creator Norman Walsh]}
+{[+opts test this]}
+{[+date 2022-09-04]}
+
 { from the 'Renaming' use case in the pragmas proposal }
-{[+ixmlns:n "https://nineml.org/ns"]}
+
 input: date; iso .
 
 -date: day, -" ", month, -" ", year.
 day: d, d?.
-@month: ("January"; "Feb", {[n:rewrite "tacular"]} "ruary") .
+@month: ("January"; "Feb", {[rewrite "tacular"]} "ruary") .
 year: d, d, d, d.
 
--iso: year, -"-", ({[n:rename month]} nmonth), -"-", day.
+-iso: year, -"-", ({[rename month]} nmonth), -"-", day.
 nmonth: d, d .
 
 -d: ["0"-"9"].

--- a/src/test/resources/xmlns.ixml
+++ b/src/test/resources/xmlns.ixml
@@ -1,6 +1,6 @@
-{[+ixmlns:n "https://nineml.org/ns"]}
-{[+n:ns "http://example.com/"]}
-date: year, -"-", {[n:rename month]} nmonth, -"-", day.
+{[+pragma n "https://nineml.org/ns/pragma/"]}
+{[+n ns "http://example.com/"]}
+date: year, -"-", {[n rename month]} nmonth, -"-", day.
 nmonth: d, d .
 year: d, d, d, d.
 day: d, d.

--- a/tools/docbook.xsl
+++ b/tools/docbook.xsl
@@ -15,8 +15,8 @@
 
 <xsl:import href="../website/docbook.xsl"/>
 
-<xsl:param name="css-links"
-           select="'css/docbook.css css/docbook-screen.css css/nineml.css css/coffeefilter.css'"/>
+<xsl:param name="user-css-links"
+           select="'css/nineml.css css/coffeefilter.css'"/>
 
 <!-- ============================================================ -->
 


### PR DESCRIPTION
The pragma syntax hadn't yet been brought up-to-date with the paper published in Balisage 2022.

Inspired by RDF and CURIEs, I've also implemented a slightly unorthadox trick where a pragma URI that ends with a slash is automatically concatenated with the first word of the pragma data to get the "real" pragma URI. Hmph.