### PR TITLE
remove setting of log level from within InvisibleXmlParser constructor

### DIFF
--- a/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
+++ b/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java
@@ -7,7 +7,6 @@ import org.nineml.coffeefilter.model.IxmlCompiler;
 import org.nineml.coffeegrinder.parser.*;
 import org.nineml.coffeegrinder.tokens.Token;
 import org.nineml.coffeegrinder.tokens.TokenCharacter;
-import org.nineml.logging.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +49,6 @@ public class InvisibleXmlParser {
         parseTime = parseMillis;
         failedParse = failed;
         this.options = options;
-        options.getLogger().setDefaultLogLevel(Logger.INFO);
     }
 
     protected InvisibleXmlParser(InvisibleXmlDocument failed, Exception exception, long parseMillis) {


### PR DESCRIPTION
When I was reusing an `InvisibleXml` object for multiple tests, the log level turned from `ERROR` to `INFO` after the first grammar that failed. All further parses after that point had `INFO` logging.

The `InvisibleXml` object was constructed without explicit `ParserOptions`:
```java
    private static InvisibleXml ixml = new InvisibleXml();
```
When I supply explicit `ParserOptions`, their `Logger`'s log level is affected as well.

This is caused by [this constructor](https://github.com/nineml/coffeefilter/blob/d6d075a82d88b93ee42ac5c19108dfd1836906bc/src/main/java/org/nineml/coffeefilter/InvisibleXmlParser.java#L48-L54):
```java
    protected InvisibleXmlParser(InvisibleXmlDocument failed, ParserOptions options, long parseMillis) {
        ixml = null;
        parseTime = parseMillis;
        failedParse = failed;
        this.options = options;
        options.getLogger().setDefaultLogLevel(Logger.INFO);
    }
```
I presume that changing the log level is not intended at this point.