### PR TITLE
Make StringTreeBuilder independent of default encoding

### DIFF
--- a/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
@@ -7,6 +7,8 @@ import org.xml.sax.SAXException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 /**
@@ -39,7 +41,13 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
     public StringTreeBuilder(ParserOptions options) {
         super(options);
         baos = new ByteArrayOutputStream();
-        stream = new PrintStream(baos);
+        try {
+          stream = new PrintStream(baos, false, StandardCharsets.UTF_8.name());
+        }
+        catch (UnsupportedEncodingException e) {
+          // this can never happen
+          throw new RuntimeException(e);
+        }
         documentElement = true;
     }
 
@@ -64,7 +72,7 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
         if (baos == null) {
             return null;
         }
-        String xml = baos.toString();
+        String xml = new String(baos.toByteArray(), StandardCharsets.UTF_8);
         baos = null;
         return xml;
     }


### PR DESCRIPTION
When using the no-argument `InvisibleXmlDocument.getTree` in an environment where the default encoding is not UTF-8, non-ASCII characters may get lost. This is caused by `StringTreeBuilder`, which [instantiates](https://github.com/nineml/coffeefilter/blob/d6d075a82d88b93ee42ac5c19108dfd1836906bc/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java#L41-L42) a `PrintStream` writing to a `ByteOutputStream`,

```java
      baos = new ByteArrayOutputStream();
      stream = new PrintStream(baos);
```

and later on [retrieves](https://github.com/nineml/coffeefilter/blob/d6d075a82d88b93ee42ac5c19108dfd1836906bc/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java#L67) the bytes,

```java
      String xml = baos.toString();
```
where either depends on the default encoding.

This fix uses UTF-8 for both the `StringTreeBuilder` instantiation and the creation of the result.

The problem was found when running `fn:invisible-xml` on BaseX, where [the implementation](https://github.com/BaseXdb/basex/blob/9577d3e479bd7d94d710588baa51f8730f4eb133/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java#L111) uses `InvisibleXmlDocument.getTree`. 