### PR TITLE
Use character entity when serializing CR

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=2.0.0
+filterVersion=2.0.1
 
 grinderName=coffeegrinder
 grinderVersion=2.0.0

--- a/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
@@ -189,6 +189,9 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
                 case '&':
                     stream.print("&amp;");
                     break;
+                case '\r':
+                    stream.print("&#xD;");
+                    break;
                 default:
                     stream.print(ch[pos]);
                     break;


### PR DESCRIPTION
`StringTreeBuilder` serializes plain carriage-return characters. This makes them get lost by end-of-line normalization, when the result goes through an XML parser. This change uses a character entity `&#xD;` instead.