### PR TITLE
Fix encoding of C0 and C1 controls and '>'

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=2.0.2
+filterVersion=2.0.3
 
 grinderName=coffeegrinder
 grinderVersion=2.0.0

--- a/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/trees/StringTreeBuilder.java
@@ -151,6 +151,9 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
                     case '<':
                         sb.append("&lt;");
                         break;
+                    case '>':
+                        sb.append("&gt;");
+                        break;
                     case '&':
                         sb.append("&amp;");
                         break;
@@ -164,7 +167,11 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
                         sb.append(String.format("&#x%X;", ch));
                         break;
                     default:
-                        sb.appendCodePoint(ch);
+                        if (ch <= 0x1F || (ch >= 0x7F && ch <= 0x9F)) {
+                            sb.append(String.format("&#x%X;", ch));
+                        } else {
+                            sb.appendCodePoint(ch);
+                        }
                         break;
                 }
             }
@@ -222,6 +229,9 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
                 case '<':
                     stream.print("&lt;");
                     break;
+                case '>':
+                    stream.print("&gt;");
+                    break;
                 case '&':
                     stream.print("&amp;");
                     break;
@@ -230,8 +240,16 @@ public class StringTreeBuilder extends AbstractTreeBuilder {
                 case LINE_SEPARATOR:
                     stream.printf("&#x%X;", (int) ch[pos]);
                     break;
-                default:
+                case TAB:
+                case LF:
                     stream.print(ch[pos]);
+                    break;
+                default:
+                    if (ch[pos] <= 0x1F || (ch[pos] >= 0x7F && ch[pos] <= 0x9F)) {
+                        stream.printf("&#x%X;", (int) ch[pos]);
+                    } else {
+                        stream.print(ch[pos]);
+                    }
                     break;
             }
         }

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -6,6 +6,25 @@
 
 <revhistory>
 <revision>
+  <revnumber>2.0.3</revnumber>
+  <date>2023-04-15</date>
+  <revdescription>
+    <para>Corrected the encoding of the C0 and C1 control characters. Changed the encoding of
+    <literal>&gt;</literal> so that it is always encoded as <literal>&amp;gt;</literal>. (This assures
+    that the output will never accidentally enclude <literal>]]&gt;</literal> which marks
+    the end of a CDATA section.)</para>
+  </revdescription>
+</revision>
+<revision>
+  <revnumber>2.0.2</revnumber>
+  <date>2023-04-14</date>
+  <revdescription>
+    <para>Fix encoding of characters per the
+  <link xlink:href="https://www.w3.org/TR/xslt-xquery-serialization-31/#xml-output">XML Output Method</link>
+  of <citetitle>XSLT and XQuery Serialization 3.1</citetitle>.</para>
+  </revdescription>
+</revision>
+<revision>
   <revnumber>2.0.1</revnumber>
   <date>2023-04-13</date>
   <revdescription>


### PR DESCRIPTION
In 2.0.2, I failed to address encoding of the C0 and C1 control characters. I also failed to update the change log.

In reviewing the serialization to address the C0 and C1 control characters, I realized that failing to encode `>` as `&gt;` introduced the possibility of `]]>` appearing in the output. That would be an error. Rather than try to check for that sequence and only encode when necessary, I've simply switched to always encoding `>` as `&gt;`. That's never wrong.