### PR TITLE
Update to CoffeeGrinder 2.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ systemProp.org.nineml.logging.defaultLogLevel=info
 
 filterName=coffeefilter
 filterTitle=CoffeeFilter
-filterVersion=2.1.0
+filterVersion=2.2.0
 
 grinderName=coffeegrinder
-grinderVersion=2.1.0
+grinderVersion=2.2.0
 
 xmlresolverVersion=5.1.2
 docbookVersion=5.2CR5

--- a/src/main/java/org/nineml/coffeefilter/model/Ixml.java
+++ b/src/main/java/org/nineml/coffeefilter/model/Ixml.java
@@ -310,10 +310,6 @@ public class Ixml extends XNonterminal {
                 attributes.add(new ParserAttribute("mark", ""+rule.getMark()));
                 attributes.add(new ParserAttribute("name", rule.getName()));
 
-                if (rule.getName().startsWith("$")) {
-                    attributes.add(ParserAttribute.PRUNING_ALLOWED);
-                }
-
                 if (startRule.equals(rule.getName())) {
                     for (IPragma pragma : pragmas) {
                         if (pragma instanceof IPragmaXmlns) {
@@ -377,9 +373,6 @@ public class Ixml extends XNonterminal {
                                 }
                             }
 
-                            if (cat.getName().startsWith("$")) {
-                                attributes.add(ParserAttribute.PRUNING_ALLOWED);
-                            }
                             attributes.add(new ParserAttribute("name", name));
                         }
 

--- a/src/main/java/org/nineml/coffeefilter/util/EventBuilder.java
+++ b/src/main/java/org/nineml/coffeefilter/util/EventBuilder.java
@@ -173,14 +173,11 @@ public class EventBuilder extends TreeBuilder {
         String origMark = null;
 
         if (options.getShowMarks() || options.getShowBnfNonterminals()) {
-            String pruneStr = attributes.getOrDefault(ParserAttribute.PRUNING_NAME, ParserAttribute.NOT_ALLOWED_TO_PRUNE);
-            boolean prune = ParserAttribute.ALLOWED_TO_PRUNE.equals(pruneStr);
-            boolean showHidden = options.getShowBnfNonterminals() && prune;
-            boolean showMarks = options.getShowMarks() && (!prune || showHidden);
+            boolean showHidden = options.getShowBnfNonterminals();
+            boolean showMarks = options.getShowMarks() || showHidden;
 
             if (showMarks) {
                 origMark = mark;
-                mark = "^";
             }
 
             if (showHidden) {
@@ -189,8 +186,12 @@ public class EventBuilder extends TreeBuilder {
             }
         }
 
-        if ("-".equals(mark)) {
+        if (origName == null && "-".equals(mark)) {
             return;
+        }
+
+        if (origMark != null) {
+            mark = "^";
         }
 
         Element element = new Element(mark, name, depth);
@@ -214,23 +215,24 @@ public class EventBuilder extends TreeBuilder {
 
         String name = attributes.getOrDefault("name", symbol.toString());
         String mark = attributes.getOrDefault("mark", "^");
+        String origName = null;
+        String origMark = null;
 
         if (options.getShowMarks() || options.getShowBnfNonterminals()) {
-            String pruneStr = attributes.getOrDefault(ParserAttribute.PRUNING_NAME, ParserAttribute.NOT_ALLOWED_TO_PRUNE);
-            boolean prune = ParserAttribute.ALLOWED_TO_PRUNE.equals(pruneStr);
-            boolean showHidden = options.getShowBnfNonterminals() && prune;
-            boolean showMarks = options.getShowMarks() && (!prune || showHidden);
+            boolean showHidden = options.getShowBnfNonterminals();
+            boolean showMarks = options.getShowMarks() || showHidden;
 
             if (showMarks) {
-                mark = "^";
+                origMark = mark;
             }
 
             if (showHidden) {
+                origName = name;
                 name = "n:symbol";
             }
         }
 
-        if ("-".equals(mark)) {
+        if (origName == null && "-".equals(mark)) {
             depth--;
             return;
         }

--- a/src/test/java/org/nineml/coffeefilter/AmbiguityTest.java
+++ b/src/test/java/org/nineml/coffeefilter/AmbiguityTest.java
@@ -32,10 +32,27 @@ public class AmbiguityTest {
 
         try {
             String xml = doc.getTree();
-            //System.out.println(xml);
+            Assertions.assertTrue(xml.contains("x<B><A>a</A></B>y"));
         } catch (Exception ex) {
             fail();
         }
+    }
+
+    @Test
+    public void ambigmarks() {
+        String input = "S = A, B, C | A, @B, C . A = 'a' . B = 'b' . C = 'c' .";
+
+        InvisibleXmlParser parser = invisibleXml.getParserFromIxml(input);
+        input = "abc";
+        InvisibleXmlDocument doc = parser.parse(input);
+
+        try {
+            String xml = doc.getTree();
+            Assertions.assertTrue(xml.contains("<A>a</A><B>b</B><C>c</C>") || xml.contains("a</A><C>c</C>"));
+        } catch (Exception ex) {
+            fail();
+        }
+
     }
 
     @Test

--- a/src/test/java/org/nineml/coffeefilter/OutputTest.java
+++ b/src/test/java/org/nineml/coffeefilter/OutputTest.java
@@ -27,7 +27,6 @@ public class OutputTest {
         InvisibleXmlParser parser = new InvisibleXml(options).getParserFromIxml(ixml);
         InvisibleXmlDocument doc = parser.parse("aa");
         String xml = doc.getTree();
-        //System.out.println(xml);
         Assertions.assertEquals("<S xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:mark=\"^\"><A ixml:mark=\"^\">a</A><A ixml:mark=\"^\">a</A></S>", xml);
 
         options.setShowBnfNonterminals(true);

--- a/src/test/java/org/nineml/coffeefilter/PriorityTest.java
+++ b/src/test/java/org/nineml/coffeefilter/PriorityTest.java
@@ -1,0 +1,51 @@
+package org.nineml.coffeefilter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+public class PriorityTest {
+    private InvisibleXml invisibleXml;
+    private ParserOptions options;
+
+    @Before
+    public void setup() {
+        options = new ParserOptions();
+        options.setPedantic(false);
+        invisibleXml = new InvisibleXml(options);
+    }
+
+    @Test
+    public void ambiguity1() {
+        try {
+            // The default priority of C is highest
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/prio1.ixml"));
+            String input = "xay";
+            InvisibleXmlDocument doc = parser.parse(input);
+            String xml = doc.getTree();
+            Assertions.assertTrue(xml.contains("x<C>a</C>y"));
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void ambiguity2() {
+        try {
+            // The explicit priority of B is highest
+            InvisibleXmlParser parser = invisibleXml.getParser(new File("src/test/resources/prio2.ixml"));
+            String input = "xay";
+            InvisibleXmlDocument doc = parser.parse(input);
+            String xml = doc.getTree();
+            Assertions.assertTrue(xml.contains("x<B>a</B>y"));
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+}

--- a/src/test/resources/prio1.ixml
+++ b/src/test/resources/prio1.ixml
@@ -1,0 +1,6 @@
+{[+pragma n "https://nineml.org/ns/pragma/"]}
+
+                   S = 'x', (A | {[n priority 2.5]} B | C), 'y' .
+{[n priority 1.0]} A = 'a' .
+{[n priority 2.0]} B = 'a' .
+{[n priority 3.0]} C = 'a' .

--- a/src/test/resources/prio2.ixml
+++ b/src/test/resources/prio2.ixml
@@ -1,0 +1,6 @@
+{[+pragma n "https://nineml.org/ns/pragma/"]}
+
+                   S = 'x', (A | {[n priority 4]} B | C), 'y' .
+{[n priority 1.0]} A = 'a' .
+{[n priority 2.0]} B = 'a' .
+{[n priority 3.0]} C = 'a' .

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -6,6 +6,25 @@
 
 <revhistory>
 <revision>
+  <revnumber>2.2.0</revnumber>
+  <date>2023-05-06</date>
+  <revdescription>
+<itemizedlist>
+<listitem>
+<para>Leveraging changes to the CoffeeGrinder implementation, the priority
+pragma now works correctly.
+</para>
+</listitem>
+<listitem>
+<para>References to “pruning” nonterminals has been removed (because it’s been
+removed from CoffeeGrinder).
+</para>
+</listitem>
+</itemizedlist>
+
+  </revdescription>
+</revision>
+<revision>
   <revnumber>2.1.0</revnumber>
   <date>2023-04-23</date>
   <revremark>Updated the version number for parity with CoffeeGrinder and the other tools.


### PR DESCRIPTION
This PR removes some vestiges of the "prunable" symbol feature and adds some tests to assure that the priority pragma now works correctly.
